### PR TITLE
perf(go): add Api Response Struct in http package

### DIFF
--- a/https/apiResponse.go
+++ b/https/apiResponse.go
@@ -1,0 +1,20 @@
+package https
+
+import "net/http"
+
+type ApiResponse [T any] struct {
+
+	Data T 					`json:"data"`
+	Response *http.Response `json:"response"`
+	Error  error 			`json:"error"`
+}
+
+func NewApiResponse[T any] (data T, response *http.Response, err error) ApiResponse[T] {
+	
+	apiResponse := ApiResponse[T]{
+		Data: data,
+		Response: response,
+		Error: err,
+	}
+	return apiResponse
+}

--- a/https/apiResponse.go
+++ b/https/apiResponse.go
@@ -6,15 +6,13 @@ type ApiResponse [T any] struct {
 
 	Data T 					`json:"data"`
 	Response *http.Response `json:"response"`
-	Error  error 			`json:"error"`
 }
 
-func NewApiResponse[T any] (data T, response *http.Response, err error) ApiResponse[T] {
+func NewApiResponse[T any] (data T, response *http.Response) ApiResponse[T] {
 	
 	apiResponse := ApiResponse[T]{
 		Data: data,
 		Response: response,
-		Error: err,
 	}
 	return apiResponse
 }

--- a/https/apiResponse_test.go
+++ b/https/apiResponse_test.go
@@ -1,0 +1,17 @@
+package https
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestApiResponse(t *testing.T) {
+	apiResponse := ApiResponse[string] {
+		Data: "This is error body",
+		Response: &http.Response{}}
+	expected := NewApiResponse("This is error body", &http.Response{})
+	if !reflect.DeepEqual(apiResponse, expected) {
+		t.Errorf("Failed:\nExpected: %v\nGot: %v", expected, apiResponse)
+	}
+}


### PR DESCRIPTION
# Description

## What
perf(go): add Api Response Struct in http package
Closes #16 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change in the generated SDKs)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Impact Area
Select multiple if applicable.

- [x] CodeGen - No impact on the SDKs
- [ ] DocsGen - Requires docs to be regenerated
- [ ] HTTP Docs
- [ ] .NET SDK/README
- [ ] Java SDK/README
- [ ] Python SDK/README
- [ ] Ruby SDK/README
- [ ] PHP SDK/README
- [ ] TypeScript SDK/README
- [ ] Swift SDK/README
- [x] GoLang SDK/README

## How Has This Been Tested?

- [x] Running test is not required
- [x] I ran the SDK tests using the local test server
- [ ] I ran the SDK tests using GitHub action
- [x] I compared the generated SDKs to ensure that there is no unintended change

## Checklist:

- [ ] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the codegen feature matrix sheet or relevant documentation.
- [ ] I have added new unit tests and/or SDK tests
