### PR TITLE
fix(go): add fix for callBuilder's mergePath function

### DIFF
--- a/https/callBuilder.go
+++ b/https/callBuilder.go
@@ -633,7 +633,7 @@ func mergePath(left, right string) string {
 	}
 
 	if left[len(left)-1] == '/' && right[0] == '/' {
-		return left + strings.Replace(right, "/", "", -1)
+		return left + strings.Replace(right, "/", "", 1)
 	} else if left[len(left)-1] == '/' || right[0] == '/' {
 		return left + right
 	} else {

--- a/https/callBuilder_test.go
+++ b/https/callBuilder_test.go
@@ -46,6 +46,32 @@ func TestAppendPath(t *testing.T) {
 	}
 }
 
+func TestAppendMultiplePath(t *testing.T) {
+	samplePath := "/number/integer/base64"
+	request := GetCallBuilder(ctx, "GET", "//response/", nil)
+	request.AppendPath(samplePath)
+	_, response, _ := request.CallAsJson()
+	responsePath := response.Request.URL.Path
+	expected := "/response" + samplePath
+
+	if responsePath != expected {
+		t.Errorf("Failed:\nExpected: %v\nGot: %v", expected, responsePath)
+	}
+}
+
+func TestAppendPathWithMultiSlashes(t *testing.T) {
+	samplePath := "//number//integer//base64"
+	request := GetCallBuilder(ctx, "GET", "//response/", nil)
+	request.AppendPath(samplePath)
+	_, response, _ := request.CallAsJson()
+	responsePath := response.Request.URL.Path
+	expected := "/response" + strings.Replace(samplePath, "//", "/", -1)
+
+	if responsePath != expected {
+		t.Errorf("Failed:\nExpected: %v\nGot: %v", expected, responsePath)
+	}
+}
+
 func TestAppendPathEmptyPath(t *testing.T) {
 	request := GetCallBuilder(ctx, "GET", "", nil)
 	request.AppendPath("/response/integer")


### PR DESCRIPTION
## What
The PR enhance the functionality of callBuilder's mergePath function.
[BUG] callBuilder's mergePath merges all path segments
## Why
The changes made in the PR enhance the functionality of the callBuilder's mergePath function. This PR fixes a corner case for mergePath function where all parts of the path were merged together into a single string.

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
No breaking changes introduced in this PR.

## Testing
I added new test cases to evaluate the code with the latest changes.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
