### PR TITLE
ci: Automatically prefix v for version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github_token: ${{ secrets.TAGS_TOKEN }}
           custom_tag: ${{ github.event.inputs.Version }}
-          tag_prefix: ""
+          tag_prefix: "v"
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Updated the GH Action so that we don't have to prefix v every time we release.