### PR TITLE
fix(go): add a fix for handling array serialization in from and query parameters in the Core library.

### DIFF
--- a/https/formData.go
+++ b/https/formData.go
@@ -125,9 +125,9 @@ func toMap(keyPrefix string, paramObj any, option ArraySerializationOption) (map
 	}
 
 	var param any
-	bytes, err := json.Marshal(toStructPtr(paramObj))
-	if err == nil {
-		err = json.Unmarshal(bytes, &param)
+	marshalBytes, err := json.Marshal(toStructPtr(paramObj))
+	if err == nil && reflect.TypeOf(paramObj).Kind() != reflect.Map {
+		err = json.Unmarshal(marshalBytes, &param)
 		if err != nil {
 			return map[string][]string{}, nil
 		}

--- a/https/httpConfiguration.go
+++ b/https/httpConfiguration.go
@@ -9,10 +9,9 @@ type HttpConfigurationOptions func(*HttpConfiguration)
 
 // HttpConfiguration holds the configuration options for the HTTP client.
 type HttpConfiguration struct {
-	timeout                  float64
-	transport                http.RoundTripper
-	retryConfiguration       RetryConfiguration
-	arraySerializationOption ArraySerializationOption
+	timeout            float64
+	transport          http.RoundTripper
+	retryConfiguration RetryConfiguration
 }
 
 // Timeout returns the configured timeout value for the HTTP client.

--- a/https/httpConfiguration.go
+++ b/https/httpConfiguration.go
@@ -30,11 +30,6 @@ func (h *HttpConfiguration) RetryConfiguration() RetryConfiguration {
 	return h.retryConfiguration
 }
 
-// ArraySerializationOption returns the configured array serialization option for the HTTP client.
-func (h *HttpConfiguration) ArraySerializationOption() ArraySerializationOption {
-	return h.arraySerializationOption
-}
-
 // NewHttpConfiguration creates a new HttpConfiguration with the provided options and returns it.
 // The options parameter allows setting different configuration options for the HTTP client.
 func NewHttpConfiguration(options ...HttpConfigurationOptions) HttpConfiguration {
@@ -64,12 +59,5 @@ func WithTransport(transport http.RoundTripper) HttpConfigurationOptions {
 func WithRetryConfiguration(retryConfig RetryConfiguration) HttpConfigurationOptions {
 	return func(h *HttpConfiguration) {
 		h.retryConfiguration = retryConfig
-	}
-}
-
-// WithArraySerializationOption sets the array serialization option for the HTTP client.
-func WithArraySerializationOption(option ArraySerializationOption) HttpConfigurationOptions {
-	return func(h *HttpConfiguration) {
-		h.arraySerializationOption = option
 	}
 }


### PR DESCRIPTION
## What
fix(go): add a fix for handling array serialization in from and query parameters in the Core library.

This pull request enhances the functionality of handling array serialization in From and Query Params.

## Why
The changes made in this pull request improve the functionality of handling array serialization in From and Query Params. It addresses a specific case to hotfix the handling of form parameters where inner form parameters require different array serialization options.   

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
No breaking changes introduced in this PR.

## Testing
I run test cases for respective spec file to evaluate the code functionality with the latest changes.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
