### PR TITLE
fix: adds fixes for testing user-agent string locally

### DIFF
--- a/utilities/apiHelper_test.go
+++ b/utilities/apiHelper_test.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // NullableTimeToStringMap
@@ -655,9 +658,10 @@ func TestPrepareQueryParamsAppendEmptyData(t *testing.T) {
 // UpdateUserAgent
 func TestUpdateUserAgentAllArguments(t *testing.T) {
 	result := UpdateUserAgent("userAgent {os-info} {engine} {engine-version}")
-	if !strings.Contains(result, "userAgent linux go") && !strings.Contains(result, "userAgent darwin go") {
-		t.Error("Incorrect UserAgent. Got:", result)
-	}
+	os := runtime.GOOS
+	engine := runtime.Version()
+	engineVer := strings.Replace(runtime.Version(), "go", "", 1)
+	assert.Equal(t, "userAgent "+os+" "+engine+" "+engineVer, result)
 }
 
 func TestUpdateUserAgentEmptyArguments(t *testing.T) {
@@ -669,9 +673,9 @@ func TestUpdateUserAgentEmptyArguments(t *testing.T) {
 
 func TestUpdateUserAgent2Arguments(t *testing.T) {
 	result := UpdateUserAgent("userAgent {os-info} {engine}")
-	if !strings.Contains(result, "userAgent linux go") && !strings.Contains(result, "userAgent darwin go") {
-		t.Error("Incorrect UserAgent. Got:", result)
-	}
+	os := runtime.GOOS
+	engine := runtime.Version()
+	assert.Equal(t, "userAgent "+os+" "+engine, result)
 }
 
 func TestUpdateUserAgentWrongArguments(t *testing.T) {


### PR DESCRIPTION
## What
This PR adds correct assertions for user-agent string by unbinding them from the GH actions environment

## Why
Some unit tests were failing in local system environment

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adhares to the following guideline 

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
