### PR TITLE
fix(body-matchers): made body matcher functions generic for valid marshalling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.out
 .vscode/
+.idea/

--- a/testHelper/bodyMatchers.go
+++ b/testHelper/bodyMatchers.go
@@ -13,8 +13,8 @@ import (
 )
 
 // NativeBodyMatcher compares the JSON response body with the expected JSON body.
-func NativeBodyMatcher(test *testing.T, expectedBody string, responseObject any) {
-	responseBytes, _ := json.Marshal(responseObject)
+func NativeBodyMatcher[T any](test *testing.T, expectedBody string, responseObject T) {
+	responseBytes, _ := json.Marshal(&responseObject)
 	var expected, response interface{}
 	expectedError := json.Unmarshal([]byte(expectedBody), &expected)
 	responseError := json.Unmarshal(responseBytes, &response)
@@ -28,10 +28,20 @@ func NativeBodyMatcher(test *testing.T, expectedBody string, responseObject any)
 	}
 }
 
+// RawBodyMatcher checks if the expectedBody is contained within the JSON response body.
+func RawBodyMatcher[T any](test *testing.T, expectedBody string, responseObject T) {
+	responseBytes, _ := json.Marshal(&responseObject)
+	responseBody := string(responseBytes)
+
+	if !strings.Contains(responseBody, expectedBody) {
+		test.Errorf("got \n%v \nbut expected %v", responseBody, expectedBody)
+	}
+}
+
 // KeysBodyMatcher compares the JSON response body with the expected JSON body using keys only.
 // The responseObject and expectedBody should have the same keys.
-func KeysBodyMatcher(test *testing.T, expectedBody string, responseObject any, checkArrayCount, checkArrayOrder bool) {
-	responseBytes, _ := json.Marshal(responseObject)
+func KeysBodyMatcher[T any](test *testing.T, expectedBody string, responseObject T, checkArrayCount, checkArrayOrder bool) {
+	responseBytes, _ := json.Marshal(&responseObject)
 	var response, expected map[string]interface{}
 	responseErr := json.Unmarshal(responseBytes, &response)
 	expectedErr := json.Unmarshal([]byte(expectedBody), &expected)
@@ -84,16 +94,6 @@ func matchKeysAndValues(response, expected map[string]interface{}, checkArrayCou
 		}
 	}
 	return true
-}
-
-// RawBodyMatcher checks if the expectedBody is contained within the JSON response body.
-func RawBodyMatcher(test *testing.T, expectedBody string, responseObject any) {
-	responseBytes, _ := json.Marshal(responseObject)
-	responseBody := string(responseBytes)
-
-	if !strings.Contains(responseBody, expectedBody) {
-		test.Errorf("got \n%v \nbut expected %v", responseBody, expectedBody)
-	}
 }
 
 // IsSameAsFile checks if the responseFileBytes is the same as the content of the file fetched from the expectedFileURL.

--- a/testHelper/bodyMatchers_test.go
+++ b/testHelper/bodyMatchers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/apimatic/go-core-runtime/https"
 )
 
-//  Native Body Matcher Tests
+// Native Body Matcher Tests
 func TestNativeBodyMatcherNumber(t *testing.T) {
 	expected := `4`
 	var result int = 4
@@ -53,7 +53,7 @@ func TestNativeBodyMatcherBooleanError(t *testing.T) {
 	NativeBodyMatcher(&testing.T{}, expected, result)
 }
 
-//  Raw Body Matcher Tests
+// Raw Body Matcher Tests
 func TestRawBodyMatcherIntSlice(t *testing.T) {
 	expected := `[1,2,3,4,5]`
 	var result []int = []int{
@@ -68,7 +68,7 @@ func TestRawBodyMatcherBooleanError(t *testing.T) {
 	RawBodyMatcher(&testing.T{}, expected, result)
 }
 
-//  Is Same File Tests
+// Is Same File Tests
 func TestIsSameFile(t *testing.T) {
 	expected := `https://www.gstatic.com/webp/gallery/1.jpg`
 	result, err := https.GetFile(expected)
@@ -90,13 +90,13 @@ func TestIsSameFileErrorURL(t *testing.T) {
 	IsSameAsFile(&testing.T{}, expected, result.File)
 }
 
-//  Slice to Comma Separated String Tests
+// Slice to Comma Separated String Tests
 func TestSliceToCommaSeparatedString(t *testing.T) {
 	expected := `{"isMap": false,"id": "5a9fcb01caacc310dc6bab50"}`
 	SliceToCommaSeparatedString(expected)
 }
 
-//  Keys And Values Body Matcher Tests
+// Keys And Values Body Matcher Tests
 type Response struct {
 	IsMap      bool       `json:"isMap"`
 	Attributes Attributes `json:"attributes"`
@@ -205,10 +205,10 @@ func TestKeysAndValuesBodyMatcherUnmarshallingError(t *testing.T) {
 	KeysAndValuesBodyMatcher(&testing.T{}, expected, result, true, false)
 }
 
-//  Keys Body Matcher Tests
+// Keys Body Matcher Tests
 func TestKeysBodyMatcherEmpty(t *testing.T) {
 	expected := `{}`
-	KeysBodyMatcher(t, expected, nil, false, false)
+	KeysBodyMatcher[any](t, expected, nil, false, false)
 }
 
 func TestKeysBodyMatcherObject(t *testing.T) {


### PR DESCRIPTION
## What
This PR fixes the non-typed behavior of body matchers by making it generic

## Why
We were required to call the correct marshal functions which are only binded to the pointer of types. This type was previously being lost.

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
The PR is not introducing any breaking changes

## Testing
I have updated unit tests to test my changes

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
