### PR TITLE
fix: invalid content-type for arrays in request body

### DIFF
--- a/testHelper/bodyMatchers_test.go
+++ b/testHelper/bodyMatchers_test.go
@@ -111,6 +111,17 @@ func TestKeysAndValuesBodyMatcherEmpty(t *testing.T) {
 	KeysAndValuesBodyMatcher[any](t, expected, nil, false, false)
 }
 
+func TestKeysAndValuesBodyMatcherEmptyArray(t *testing.T) {
+	expected := `[]`
+	KeysAndValuesBodyMatcher[any](t, expected, nil, false, false)
+}
+
+func TestKeysAndValuesBodyMatcherArray(t *testing.T) {
+	expected := `["some string", 123]`
+	result := []any{"some string", 123}
+	KeysAndValuesBodyMatcher(t, expected, result, false, false)
+}
+
 func TestKeysAndValuesBodyMatcherObject(t *testing.T) {
 	expected := `{"id": "5a9fcb01caacc310dc6bab51"}`
 	result := Attributes{
@@ -209,6 +220,17 @@ func TestKeysAndValuesBodyMatcherUnmarshallingError(t *testing.T) {
 func TestKeysBodyMatcherEmpty(t *testing.T) {
 	expected := `{}`
 	KeysBodyMatcher[any](t, expected, nil, false, false)
+}
+
+func TestKeysBodyMatcherEmptyArray(t *testing.T) {
+	expected := `[]`
+	KeysBodyMatcher[any](t, expected, nil, false, false)
+}
+
+func TestKeysBodyMatcherArray(t *testing.T) {
+	expected := `["some string", 123]`
+	result := []any{"123", 765}
+	KeysBodyMatcher(t, expected, result, false, false)
 }
 
 func TestKeysBodyMatcherObject(t *testing.T) {

--- a/testHelper/bodyMatchers_test.go
+++ b/testHelper/bodyMatchers_test.go
@@ -98,9 +98,10 @@ func TestSliceToCommaSeparatedString(t *testing.T) {
 
 // Keys And Values Body Matcher Tests
 type Response struct {
-	IsMap      bool       `json:"isMap"`
-	Attributes Attributes `json:"attributes"`
-	Id         string     `json:"id"`
+	IsMap           bool         `json:"isMap"`
+	Attributes      Attributes   `json:"attributes"`
+	AttributesArray []Attributes `json:"attributesArray"`
+	Id              string       `json:"id"`
 }
 type Attributes struct {
 	Id string `json:"id"`
@@ -142,6 +143,26 @@ func TestKeysAndValuesBodyMatcherNestedObject(t *testing.T) {
 		IsMap: false,
 		Attributes: Attributes{
 			Id: "5a9fcb01caacc310dc6bab51",
+		},
+		Id: "5a9fcb01caacc310dc6bab50",
+	}
+	KeysAndValuesBodyMatcher(t, expected, result, false, false)
+}
+
+func TestKeysAndValuesBodyMatcherNestedArray(t *testing.T) {
+	expected := `{
+        "isMap": false,
+        "attributesArray": [
+			{
+          		"id": "5a9fcb01caacc310dc6bab51"
+			}
+		],
+        "id": "5a9fcb01caacc310dc6bab50"
+    }`
+	result := Response{
+		IsMap: false,
+		AttributesArray: []Attributes{
+			{Id: "5a9fcb01caacc310dc6bab51"},
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
@@ -237,6 +258,26 @@ func TestKeysBodyMatcherObject(t *testing.T) {
 	expected := `{"id": "5a9fcb01caacc310dc6bab51"}`
 	result := Attributes{
 		Id: "5a9fcb01caacc310dc6bab51",
+	}
+	KeysBodyMatcher(t, expected, result, false, false)
+}
+
+func TestKeysBodyMatcherNestedArray(t *testing.T) {
+	expected := `{
+        "isMap": false,
+        "attributesArray": [
+			{
+          		"id": "5a9fcb01caacc310dc6bab51"
+			}
+		],
+        "id": "5a9fcb01caacc310dc6bab50"
+    }`
+	result := Response{
+		IsMap: false,
+		AttributesArray: []Attributes{
+			{Id: "5a9fcb01caacc310dc6bab51"},
+		},
+		Id: "5a9fcb01caacc310dc6bab50",
 	}
 	KeysBodyMatcher(t, expected, result, false, false)
 }


### PR DESCRIPTION
## What
This PR fixes 2 different bugs:
- invalid content-type for arrays in request body
- body matcher issue for array handling

## Why
These bugs were causing runtime issues with multiple SDKs

Closes #71

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [X] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
Unit tests are added to test the new functionality

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
