### PR TITLE
refactor(go): add support for Date time format for OAF classes

### DIFF
--- a/utilities/internal_time_types.go
+++ b/utilities/internal_time_types.go
@@ -59,43 +59,6 @@ func NewRFC1123Time(t time.Time) RFC1123Time {
 	return RFC1123Time{Time: t}
 }
 
-type TimeTypes interface {
-	RFC1123Time | RFC3339Time | UnixDateTime | DefaultTime
-	Value() time.Time
-}
-
-func ObjMapToTimeMap[T TimeTypes](objMap map[string]T) map[string]time.Time {
-	finalMap := map[string]time.Time{}
-	for k, v := range objMap {
-		finalMap[k] = v.Value()
-	}
-	return finalMap
-}
-
-func ObjSliceToTimeSlice[T TimeTypes](objSlice []T) []time.Time {
-	finalSlice := []time.Time{}
-	for k, v := range objSlice {
-		finalSlice[k] = v.Value()
-	}
-	return finalSlice
-}
-
-func TimeMapToObjMap[T TimeTypes](timeMap map[string]time.Time) map[string]T {
-	finalMap := map[string]T{}
-	for k, v := range timeMap {
-		finalMap[k] = T{v}
-	}
-	return finalMap
-}
-
-func TimeSliceToObjSlice[T TimeTypes](timeSlice []time.Time) []T {
-	finalSlice := []T{}
-	for k, v := range timeSlice {
-		finalSlice[k] = T{v}
-	}
-	return finalSlice
-}
-
 func (t RFC1123Time) Value() time.Time { return t.Time }
 
 // String returns RFC1123Time as a string following the RFC1123 standard.
@@ -151,4 +114,41 @@ func (u *UnixDateTime) UnmarshalJSON(input []byte) error {
 	}
 	u.Time = time.Unix(temp, 0)
 	return nil
+}
+
+type TimeTypes interface {
+	RFC1123Time | RFC3339Time | UnixDateTime | DefaultTime
+	Value() time.Time
+}
+
+func ObjMapToTimeMap[T TimeTypes](objMap map[string]T) map[string]time.Time {
+	finalMap := map[string]time.Time{}
+	for k, v := range objMap {
+		finalMap[k] = v.Value()
+	}
+	return finalMap
+}
+
+func ObjSliceToTimeSlice[T TimeTypes](objSlice []T) []time.Time {
+	finalSlice := make([]time.Time, len(objSlice))
+	for k, v := range objSlice {
+		finalSlice[k] = v.Value()
+	}
+	return finalSlice
+}
+
+func TimeMapToObjMap[T TimeTypes](timeMap map[string]time.Time) map[string]T {
+	finalMap := map[string]T{}
+	for k, v := range timeMap {
+		finalMap[k] = T{v}
+	}
+	return finalMap
+}
+
+func TimeSliceToObjSlice[T TimeTypes](timeSlice []time.Time) []T {
+	finalSlice := make([]T, len(timeSlice))
+	for k, v := range timeSlice {
+		finalSlice[k] = T{v}
+	}
+	return finalSlice
 }

--- a/utilities/internal_time_types.go
+++ b/utilities/internal_time_types.go
@@ -1,0 +1,154 @@
+package utilities
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// DefaultTime is a struct that implements time.Time with custom formatting.
+type DefaultTime struct{ time.Time }
+
+func NewDefaultTime(t time.Time) DefaultTime {
+	return DefaultTime{Time: t}
+}
+
+func (t DefaultTime) Value() time.Time { return t.Time }
+
+// String returns DefaultTime as string value by following its defined format.
+func (t DefaultTime) String() string { return t.Format(DEFAULT_DATE) }
+
+// MarshalJSON implements json.Marshaller interface to customize JSON marshaling for DefaultTime objects.
+func (t DefaultTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Format(DEFAULT_DATE))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface to customize JSON unmarshalling for DefaultTime objects.
+func (t *DefaultTime) UnmarshalJSON(input []byte) (err error) {
+	t.Time, err = unmarshalTime(input, DEFAULT_DATE)
+	return err
+}
+
+// RFC3339Time is a struct that implements time.Time with custom formatting.
+type RFC3339Time struct{ time.Time }
+
+func NewRFC3339Time(t time.Time) RFC3339Time {
+	return RFC3339Time{Time: t}
+}
+
+func (t RFC3339Time) Value() time.Time { return t.Time }
+
+// String returns RFC3339Time as a string following the RFC3339 standard.
+func (t RFC3339Time) String() string { return t.Format(time.RFC3339Nano) }
+
+// MarshalJSON implements json.Marshaller interface to customize JSON marshaling for RFC3339Time objects.
+func (t RFC3339Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Format(time.RFC3339Nano))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface to customize JSON unmarshalling for RFC3339Time objects.
+func (t *RFC3339Time) UnmarshalJSON(input []byte) (err error) {
+	t.Time, err = unmarshalTime(input, time.RFC3339Nano)
+	return err
+}
+
+// RFC1123Time is a struct that implements time.Time with custom formatting.
+type RFC1123Time struct{ time.Time }
+
+func NewRFC1123Time(t time.Time) RFC1123Time {
+	return RFC1123Time{Time: t}
+}
+
+type TimeTypes interface {
+	RFC1123Time | RFC3339Time | UnixDateTime | DefaultTime
+	Value() time.Time
+}
+
+func ObjMapToTimeMap[T TimeTypes](objMap map[string]T) map[string]time.Time {
+	finalMap := map[string]time.Time{}
+	for k, v := range objMap {
+		finalMap[k] = v.Value()
+	}
+	return finalMap
+}
+
+func ObjSliceToTimeSlice[T TimeTypes](objSlice []T) []time.Time {
+	finalSlice := []time.Time{}
+	for k, v := range objSlice {
+		finalSlice[k] = v.Value()
+	}
+	return finalSlice
+}
+
+func TimeMapToObjMap[T TimeTypes](timeMap map[string]time.Time) map[string]T {
+	finalMap := map[string]T{}
+	for k, v := range timeMap {
+		finalMap[k] = T{v}
+	}
+	return finalMap
+}
+
+func TimeSliceToObjSlice[T TimeTypes](timeSlice []time.Time) []T {
+	finalSlice := []T{}
+	for k, v := range timeSlice {
+		finalSlice[k] = T{v}
+	}
+	return finalSlice
+}
+
+func (t RFC1123Time) Value() time.Time { return t.Time }
+
+// String returns RFC1123Time as a string following the RFC1123 standard.
+func (t RFC1123Time) String() string { return t.Format(time.RFC1123) }
+
+// MarshalJSON implements json.Marshaller interface to customize JSON marshaling for RFC1123Time objects.
+func (t RFC1123Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Format(time.RFC1123))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface to customize JSON unmarshalling for RFC1123Time objects.
+func (t *RFC1123Time) UnmarshalJSON(input []byte) (err error) {
+	t.Time, err = unmarshalTime(input, time.RFC1123)
+	return err
+}
+
+func unmarshalTime(input []byte, layout string) (time.Time, error) {
+	var temp string
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return time.Time{}, err
+	}
+	if timeVal, err := time.Parse(layout, temp); err == nil {
+		return timeVal, nil
+	} else {
+		return time.Time{}, err
+	}
+}
+
+// UnixDateTime is a struct that implements time.Time with custom formatting.
+type UnixDateTime struct{ time.Time }
+
+func NewUnixDateTime(t time.Time) UnixDateTime {
+	return UnixDateTime{Time: t}
+}
+
+func (t UnixDateTime) Value() time.Time { return t.Time }
+
+// String returns UnixDateTime as a string following the Unix standard.
+func (u UnixDateTime) String() string {
+	return fmt.Sprintf("%v", u.Unix())
+}
+
+// MarshalJSON implements json.Marshaller interface to customize JSON marshaling for UnixDateTime objects.
+func (u UnixDateTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.Unix())
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface to customize JSON unmarshalling for UnixDateTime objects.
+func (u *UnixDateTime) UnmarshalJSON(input []byte) error {
+	var temp int64
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return err
+	}
+	u.Time = time.Unix(temp, 0)
+	return nil
+}

--- a/utilities/internal_time_types_test.go
+++ b/utilities/internal_time_types_test.go
@@ -26,7 +26,8 @@ func TestUnixDateTime(t *testing.T) {
 
 func TestUnixDateTimeError(t *testing.T) {
 	var newUnixDateTime UnixDateTime
-	json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newUnixDateTime)
+	err := json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newUnixDateTime)
+	AssertError(t, err)
 }
 
 func TestDefaultTimeString(t *testing.T) {
@@ -51,12 +52,14 @@ func TestDefaultTime(t *testing.T) {
 
 func TestDefaultTimeError1(t *testing.T) {
 	var newDefaultTime DefaultTime
-	json.Unmarshal([]byte(`1484719381`), &newDefaultTime)
+	err := json.Unmarshal([]byte(`1484719381`), &newDefaultTime)
+	AssertError(t, err)
 }
 
 func TestDefaultTimeError2(t *testing.T) {
 	var newDefaultTime DefaultTime
-	json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newDefaultTime)
+	err := json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newDefaultTime)
+	AssertError(t, err)
 }
 
 func TestRFC3339TimeString(t *testing.T) {

--- a/utilities/internal_time_types_test.go
+++ b/utilities/internal_time_types_test.go
@@ -1,0 +1,130 @@
+package utilities
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestUnixDateTimeString(t *testing.T) {
+	newTime := time.Unix(1484719381, 0)
+	unixDateTime := NewUnixDateTime(newTime)
+	AssertEquals(t, "1484719381", unixDateTime.String())
+}
+
+func TestUnixDateTime(t *testing.T) {
+	newTime := time.Unix(1484719381, 0)
+	unixDateTime := NewUnixDateTime(newTime)
+
+	bytes, err := json.Marshal(unixDateTime)
+	AssertNoError(t, err)
+	var newUnixDateTime UnixDateTime
+	err = json.Unmarshal(bytes, &newUnixDateTime)
+	AssertNoError(t, err)
+	AssertEquals(t, newTime, newUnixDateTime.Value())
+}
+
+func TestUnixDateTimeError(t *testing.T) {
+	var newUnixDateTime UnixDateTime
+	json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newUnixDateTime)
+}
+
+func TestDefaultTimeString(t *testing.T) {
+	newTime, err := time.Parse(DEFAULT_DATE, "1994-02-13")
+	AssertNoError(t, err)
+	defaultTime := NewDefaultTime(newTime)
+	AssertEquals(t, "1994-02-13", defaultTime.String())
+}
+
+func TestDefaultTime(t *testing.T) {
+	newTime, err := time.Parse(DEFAULT_DATE, "1994-02-13")
+	AssertNoError(t, err)
+	defaultTime := NewDefaultTime(newTime)
+
+	bytes, err := json.Marshal(defaultTime)
+	AssertNoError(t, err)
+	var newDefaultTime DefaultTime
+	err = json.Unmarshal(bytes, &newDefaultTime)
+	AssertNoError(t, err)
+	AssertEquals(t, newTime, newDefaultTime.Value())
+}
+
+func TestDefaultTimeError1(t *testing.T) {
+	var newDefaultTime DefaultTime
+	json.Unmarshal([]byte(`1484719381`), &newDefaultTime)
+}
+
+func TestDefaultTimeError2(t *testing.T) {
+	var newDefaultTime DefaultTime
+	json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newDefaultTime)
+}
+
+func TestRFC3339TimeString(t *testing.T) {
+	newTime, err := time.Parse(time.RFC3339Nano, "1994-02-13T14:01:54.9571247Z")
+	AssertNoError(t, err)
+	rFC3339Time := NewRFC3339Time(newTime)
+	AssertEquals(t, "1994-02-13T14:01:54.9571247Z", rFC3339Time.String())
+}
+
+func TestRFC3339Time(t *testing.T) {
+	newTime, err := time.Parse(time.RFC3339Nano, "1994-02-13T14:01:54.9571247Z")
+	AssertNoError(t, err)
+	rFC3339Time := NewRFC3339Time(newTime)
+
+	bytes, err := json.Marshal(rFC3339Time)
+	AssertNoError(t, err)
+	var newRFC3339Time RFC3339Time
+	err = json.Unmarshal(bytes, &newRFC3339Time)
+	AssertNoError(t, err)
+	AssertEquals(t, newTime, newRFC3339Time.Value())
+}
+
+func TestRFC1123TimeString(t *testing.T) {
+	newTime, err := time.Parse(time.RFC1123, "Sun, 06 Nov 1994 08:49:37 GMT")
+	AssertNoError(t, err)
+	rFC1123Time := NewRFC1123Time(newTime)
+	AssertEquals(t, "Sun, 06 Nov 1994 08:49:37 GMT", rFC1123Time.String())
+}
+
+func TestRFC1123Time(t *testing.T) {
+	newTime, err := time.Parse(time.RFC1123, "Sun, 06 Nov 1994 08:49:37 GMT")
+	AssertNoError(t, err)
+	rFC1123Time := NewRFC1123Time(newTime)
+
+	bytes, err := json.Marshal(rFC1123Time)
+	AssertNoError(t, err)
+	var newRFC1123Time RFC1123Time
+	err = json.Unmarshal(bytes, &newRFC1123Time)
+	AssertNoError(t, err)
+	AssertEquals(t, newTime, rFC1123Time.Value())
+}
+
+func TestObjSliceToTimeSlice(t *testing.T) {
+	initialBytes := []byte(`["Sun, 06 Nov 1994 08:49:37 GMT","Sun, 06 Nov 1994 08:49:37 GMT"]`)
+	var strArray []string
+	err := json.Unmarshal(initialBytes, &strArray)
+	AssertNoError(t, err)
+	timeArray, err := ToTimeSlice(strArray, time.RFC1123)
+	AssertNoError(t, err)
+	newObjArray := TimeSliceToObjSlice[RFC1123Time](timeArray)
+	newTimeArray := ObjSliceToTimeSlice(newObjArray)
+	newStrArray := TimeToStringSlice(newTimeArray, time.RFC1123)
+	resultBytes, err := json.Marshal(newStrArray)
+	AssertNoError(t, err)
+	AssertEquals(t, string(initialBytes), string(resultBytes))
+}
+
+func TestObjMapToTimeMap(t *testing.T) {
+	initialBytes := []byte(`{"key1":"Sun, 06 Nov 1994 08:49:37 GMT","key2":"Sun, 06 Nov 1994 08:49:37 GMT"}`)
+	var strMap map[string]string
+	err := json.Unmarshal(initialBytes, &strMap)
+	AssertNoError(t, err)
+	timeMap, err := ToTimeMap(strMap, time.RFC1123)
+	AssertNoError(t, err)
+	newObjMap := TimeMapToObjMap[RFC1123Time](timeMap)
+	newTimeMap := ObjMapToTimeMap(newObjMap)
+	newStrMap := TimeToStringMap(newTimeMap, time.RFC1123)
+	resultBytes, err := json.Marshal(newStrMap)
+	AssertNoError(t, err)
+	AssertEquals(t, string(initialBytes), string(resultBytes))
+}


### PR DESCRIPTION
## What
refactor(go): add support for Date time format for OAF classes

This pull request enhances the functionality of handling date time format in oneOf anyOf classes.

## Why
The changes made in this pull request improve the functionality of handling date time format in oneOf anyOf classes. It add some additional structures for Datetime cases.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
Their is no breaking changes in this PR.

## Testing
I added additional tests for test coverage.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
