### PR TITLE
perf(go): improve go core library test validators to improve test validation

### DIFF
--- a/https/formData_test.go
+++ b/https/formData_test.go
@@ -40,8 +40,8 @@ func TestStructToMapMarshallingError(t *testing.T) {
 }
 
 func TestToMapNilMap(t *testing.T) {
-	param := FormParam{"param", "value", nil}
-	result, _ := toMap(param.Key, param.Value, Indexed)
+	param := formParam{"param", "value", nil, Indexed}
+	result, _ := param.toMap()
 
 	expected := map[string][]string{
 		"param": {"value"},
@@ -53,8 +53,8 @@ func TestToMapNilMap(t *testing.T) {
 }
 
 func TestFormEncodeMapNilValue(t *testing.T) {
-	param := FormParam{"param", nil, nil}
-	result, _ := toMap(param.Key, param.Value, Indexed)
+	param := formParam{"param", nil, nil, Indexed}
+	result, _ := param.toMap()
 
 	expected := make(map[string][]string)
 
@@ -64,8 +64,8 @@ func TestFormEncodeMapNilValue(t *testing.T) {
 }
 
 func TestFormEncodeMapStructType(t *testing.T) {
-	param := FormParam{"param2", GetStruct(), nil}
-	result, _ := toMap(param.Key, param.Value, Indexed)
+	param := formParam{"param2", GetStruct(), nil, Indexed}
+	result, _ := param.toMap()
 
 	expected := FormParams{
 		{"param2[Name]", "Bisma", nil},

--- a/testHelper/bodyMatchers.go
+++ b/testHelper/bodyMatchers.go
@@ -51,10 +51,21 @@ func KeysBodyMatcher[T any](test *testing.T, expectedBody string, responseObject
 // KeysAndValuesBodyMatcher compares the JSON response body with the expected JSON body using keys and values.
 // The responseObject and expectedBody should have the same keys and their corresponding values should be equal.
 func KeysAndValuesBodyMatcher[T any](test *testing.T, expectedBody string, responseObject T, checkArrayCount, checkArrayOrder bool) {
-	return
-	responseBytes, _ := json.Marshal(&responseObject)
+	responseBytes, responseErr := json.Marshal(&responseObject)
+	if responseErr != nil {
+		test.Errorf("Invalid response data: %v", responseErr)
+	}
+	var expectedData T
+	expectedErr := json.Unmarshal([]byte(expectedBody), &expectedData)
+	if expectedErr != nil {
+		test.Errorf("Invalid expected data: %v", expectedErr)
+	}
+	expectedBytes, expectedErr := json.Marshal(&expectedData)
+	if expectedErr != nil {
+		test.Errorf("Invalid expected data: %v", expectedErr)
+	}
 
-	if !matchKeysAndValues(responseBytes, []byte(expectedBody), checkArrayCount, checkArrayOrder, true) {
+	if !matchKeysAndValues(responseBytes, expectedBytes, checkArrayCount, checkArrayOrder, true) {
 		test.Errorf("got \n%v \nbut expected \n%v", string(responseBytes), expectedBody)
 	}
 }

--- a/testHelper/bodyMatchers.go
+++ b/testHelper/bodyMatchers.go
@@ -51,6 +51,7 @@ func KeysBodyMatcher[T any](test *testing.T, expectedBody string, responseObject
 // KeysAndValuesBodyMatcher compares the JSON response body with the expected JSON body using keys and values.
 // The responseObject and expectedBody should have the same keys and their corresponding values should be equal.
 func KeysAndValuesBodyMatcher[T any](test *testing.T, expectedBody string, responseObject T, checkArrayCount, checkArrayOrder bool) {
+	return
 	responseBytes, _ := json.Marshal(&responseObject)
 
 	if !matchKeysAndValues(responseBytes, []byte(expectedBody), checkArrayCount, checkArrayOrder, true) {

--- a/testHelper/bodyMatchers_test.go
+++ b/testHelper/bodyMatchers_test.go
@@ -1,34 +1,42 @@
 package testHelper
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"testing"
 
 	"github.com/apimatic/go-core-runtime/https"
 )
 
+func getValueReader(val any) io.ReadCloser {
+	byt, _ := json.Marshal(val)
+	return io.NopCloser(bytes.NewBuffer(byt))
+}
+
 // Native Body Matcher Tests
 func TestNativeBodyMatcherNumber(t *testing.T) {
 	expected := `4`
 	var result int = 4
-	NativeBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestNativeBodyMatcherPrecision(t *testing.T) {
 	expected := `4.11`
 	var result float32 = 4.11
-	NativeBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestNativeBodyMatcherLong(t *testing.T) {
 	expected := `411111111111111111`
 	var result int64 = 411111111111111111
-	NativeBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestNativeBodyMatcherBoolean(t *testing.T) {
 	expected := `true`
 	var result bool = true
-	NativeBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestNativeBodyMatcherStringSlice(t *testing.T) {
@@ -36,7 +44,7 @@ func TestNativeBodyMatcherStringSlice(t *testing.T) {
 	var result []string = []string{
 		"Tuesday", "Saturday", "Wednesday", "Monday", "Sunday",
 	}
-	NativeBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), true, true)
 }
 
 func TestNativeBodyMatcherIntSlice(t *testing.T) {
@@ -44,13 +52,13 @@ func TestNativeBodyMatcherIntSlice(t *testing.T) {
 	var result []int = []int{
 		1, 2, 3, 4, 5,
 	}
-	NativeBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), true, false)
 }
 
 func TestNativeBodyMatcherBooleanError(t *testing.T) {
 	expected := `nil`
 	var result bool = true
-	NativeBodyMatcher(&testing.T{}, expected, result)
+	NativeBodyMatcher(&testing.T{}, expected, getValueReader(result), false, false)
 }
 
 // Raw Body Matcher Tests
@@ -59,7 +67,7 @@ func TestRawBodyMatcherIntSlice(t *testing.T) {
 	var result []int = []int{
 		1, 2, 3, 4, 5,
 	}
-	RawBodyMatcher(t, expected, result)
+	NativeBodyMatcher(t, expected, getValueReader(result), true, false)
 }
 
 func TestRawBodyMatcherBooleanError(t *testing.T) {
@@ -109,18 +117,18 @@ type Attributes struct {
 
 func TestKeysAndValuesBodyMatcherEmpty(t *testing.T) {
 	expected := `{}`
-	KeysAndValuesBodyMatcher[any](t, expected, nil, false, false)
+	KeysAndValuesBodyMatcher(t, expected, nil, false, false)
 }
 
 func TestKeysAndValuesBodyMatcherEmptyArray(t *testing.T) {
 	expected := `[]`
-	KeysAndValuesBodyMatcher[any](t, expected, nil, false, false)
+	KeysAndValuesBodyMatcher(t, expected, nil, false, false)
 }
 
 func TestKeysAndValuesBodyMatcherArray(t *testing.T) {
 	expected := `["some string", 123]`
 	result := []any{"some string", 123}
-	KeysAndValuesBodyMatcher(t, expected, result, false, false)
+	KeysAndValuesBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestKeysAndValuesBodyMatcherObject(t *testing.T) {
@@ -128,7 +136,7 @@ func TestKeysAndValuesBodyMatcherObject(t *testing.T) {
 	result := Attributes{
 		Id: "5a9fcb01caacc310dc6bab51",
 	}
-	KeysAndValuesBodyMatcher(t, expected, result, false, false)
+	KeysAndValuesBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestKeysAndValuesBodyMatcherNestedObject(t *testing.T) {
@@ -146,7 +154,7 @@ func TestKeysAndValuesBodyMatcherNestedObject(t *testing.T) {
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
-	KeysAndValuesBodyMatcher(t, expected, result, false, false)
+	KeysAndValuesBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestKeysAndValuesBodyMatcherNestedArray(t *testing.T) {
@@ -166,7 +174,7 @@ func TestKeysAndValuesBodyMatcherNestedArray(t *testing.T) {
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
-	KeysAndValuesBodyMatcher(t, expected, result, false, false)
+	KeysAndValuesBodyMatcher(t, expected, getValueReader(result), false, false)
 }
 
 func TestKeysAndValuesBodyMatcherNestedObjectValueError(t *testing.T) {
@@ -184,7 +192,7 @@ func TestKeysAndValuesBodyMatcherNestedObjectValueError(t *testing.T) {
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
-	KeysAndValuesBodyMatcher(&testing.T{}, expected, result, false, false)
+	KeysAndValuesBodyMatcher(&testing.T{}, expected, getValueReader(result), false, false)
 }
 
 func TestKeysAndValuesBodyMatcherNestedObjectTypeError(t *testing.T) {
@@ -200,7 +208,7 @@ func TestKeysAndValuesBodyMatcherNestedObjectTypeError(t *testing.T) {
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
-	KeysAndValuesBodyMatcher(&testing.T{}, expected, result, false, false)
+	KeysAndValuesBodyMatcher(&testing.T{}, expected, getValueReader(result), false, false)
 }
 
 func TestKeysAndValuesBodyMatcherNestedObjectArrayCountError(t *testing.T) {
@@ -217,7 +225,7 @@ func TestKeysAndValuesBodyMatcherNestedObjectArrayCountError(t *testing.T) {
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
-	KeysAndValuesBodyMatcher(&testing.T{}, expected, result, true, false)
+	KeysAndValuesBodyMatcher(&testing.T{}, expected, getValueReader(result), true, false)
 }
 
 func TestKeysAndValuesBodyMatcherUnmarshallingError(t *testing.T) {
@@ -234,7 +242,7 @@ func TestKeysAndValuesBodyMatcherUnmarshallingError(t *testing.T) {
 		},
 		Id: "5a9fcb01caacc310dc6bab50",
 	}
-	KeysAndValuesBodyMatcher(&testing.T{}, expected, result, true, false)
+	KeysAndValuesBodyMatcher(&testing.T{}, expected, getValueReader(result), true, false)
 }
 
 // Keys Body Matcher Tests


### PR DESCRIPTION
## What
During the implementation of handling Datetime Format cases in the OAF implementation, I identified a loophole in the test validation process of go core library.

## Why
This issue affects the accuracy and reliability of the tests generated for the Go SDKs, potentially leading to incorrect validation of Go SDKs tests. It is crucial to address this issue promptly to ensure the correctness of the generated tests and the overall functionality of the Go SDKs.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
Existing dependencies are removed.

## Breaking change
No breaking change were introduced.

## Testing
Existing tests are updated to test the updated implementation.

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
