### PR TITLE
fix(go): query parameter of type enum array not properly serialized

### DIFF
--- a/https/apiError_test.go
+++ b/https/apiError_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/apimatic/go-core-runtime/assert"
+	"github.com/apimatic/go-core-runtime/internal"
 )
 
 const mockJSONResponseBody = `{
@@ -52,7 +52,7 @@ func TestCorrectMessageWhenDynamicErrorMessageWithStatusCode(t *testing.T) {
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, "Error: Status Code 500", actual)
+	internal.Equal(t, "Error: Status Code 500", actual)
 }
 
 func TestCorrectMessageWhenDynamicErrorMessageWithResponseHeader(t *testing.T) {
@@ -65,7 +65,7 @@ func TestCorrectMessageWhenDynamicErrorMessageWithResponseHeader(t *testing.T) {
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, "Error: Date Thu, 22 Feb 2024 06:01:57 GMT", actual)
+	internal.Equal(t, "Error: Date Thu, 22 Feb 2024 06:01:57 GMT", actual)
 }
 
 func TestDynamicErrorMessageWithResponseBody(t *testing.T) {
@@ -85,7 +85,7 @@ func TestDynamicErrorMessageWithResponseBody(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			res := getMockResponseWithJSONBody(mockJSONResponseBody)
 			actual := renderErrorTemplate(test.tpl, res)
-			assert.Equal(t, test.expected, actual)
+			internal.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -99,7 +99,7 @@ func TestEmptyStringWhenDynamicErrorMessageWithMissingResponseHeader(t *testing.
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, "Error: Date ", actual)
+	internal.Equal(t, "Error: Date ", actual)
 }
 
 func TestEmptyStringWhenDynamicErrorMessageWithResponseBodyPropertyMissing(t *testing.T) {
@@ -114,7 +114,7 @@ func TestEmptyStringWhenDynamicErrorMessageWithResponseBodyPropertyMissing(t *te
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, "Error: Code ", actual)
+	internal.Equal(t, "Error: Code ", actual)
 }
 
 func TestEmptyStringWhenDynamicErrorMessageWithInvalidJSONInResponseBody(t *testing.T) {
@@ -125,7 +125,7 @@ func TestEmptyStringWhenDynamicErrorMessageWithInvalidJSONInResponseBody(t *test
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, "Error: ", actual)
+	internal.Equal(t, "Error: ", actual)
 }
 
 func TestReturnWithoutChangesWhenDynamicErrorMessageWithInvalidPlaceholder(t *testing.T) {
@@ -134,7 +134,7 @@ func TestReturnWithoutChangesWhenDynamicErrorMessageWithInvalidPlaceholder(t *te
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, tpl, actual)
+	internal.Equal(t, tpl, actual)
 }
 
 func TestReturnWithoutChangesWhenDynamicErrorMessageWithNoTemplates(t *testing.T) {
@@ -143,5 +143,5 @@ func TestReturnWithoutChangesWhenDynamicErrorMessageWithNoTemplates(t *testing.T
 
 	actual := renderErrorTemplate(tpl, res)
 
-	assert.Equal(t, tpl, actual)
+	internal.Equal(t, tpl, actual)
 }

--- a/https/apiError_test.go
+++ b/https/apiError_test.go
@@ -3,12 +3,11 @@ package https
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/apimatic/go-core-runtime/internal/assert"
 	"io"
 	"log"
 	"net/http"
 	"testing"
-
-	"github.com/apimatic/go-core-runtime/internal"
 )
 
 const mockJSONResponseBody = `{
@@ -52,7 +51,7 @@ func TestCorrectMessageWhenDynamicErrorMessageWithStatusCode(t *testing.T) {
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, "Error: Status Code 500", actual)
+	assert.Equal(t, "Error: Status Code 500", actual)
 }
 
 func TestCorrectMessageWhenDynamicErrorMessageWithResponseHeader(t *testing.T) {
@@ -65,7 +64,7 @@ func TestCorrectMessageWhenDynamicErrorMessageWithResponseHeader(t *testing.T) {
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, "Error: Date Thu, 22 Feb 2024 06:01:57 GMT", actual)
+	assert.Equal(t, "Error: Date Thu, 22 Feb 2024 06:01:57 GMT", actual)
 }
 
 func TestDynamicErrorMessageWithResponseBody(t *testing.T) {
@@ -85,7 +84,7 @@ func TestDynamicErrorMessageWithResponseBody(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			res := getMockResponseWithJSONBody(mockJSONResponseBody)
 			actual := renderErrorTemplate(test.tpl, res)
-			internal.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -99,7 +98,7 @@ func TestEmptyStringWhenDynamicErrorMessageWithMissingResponseHeader(t *testing.
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, "Error: Date ", actual)
+	assert.Equal(t, "Error: Date ", actual)
 }
 
 func TestEmptyStringWhenDynamicErrorMessageWithResponseBodyPropertyMissing(t *testing.T) {
@@ -114,7 +113,7 @@ func TestEmptyStringWhenDynamicErrorMessageWithResponseBodyPropertyMissing(t *te
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, "Error: Code ", actual)
+	assert.Equal(t, "Error: Code ", actual)
 }
 
 func TestEmptyStringWhenDynamicErrorMessageWithInvalidJSONInResponseBody(t *testing.T) {
@@ -125,7 +124,7 @@ func TestEmptyStringWhenDynamicErrorMessageWithInvalidJSONInResponseBody(t *test
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, "Error: ", actual)
+	assert.Equal(t, "Error: ", actual)
 }
 
 func TestReturnWithoutChangesWhenDynamicErrorMessageWithInvalidPlaceholder(t *testing.T) {
@@ -134,7 +133,7 @@ func TestReturnWithoutChangesWhenDynamicErrorMessageWithInvalidPlaceholder(t *te
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, tpl, actual)
+	assert.Equal(t, tpl, actual)
 }
 
 func TestReturnWithoutChangesWhenDynamicErrorMessageWithNoTemplates(t *testing.T) {
@@ -143,5 +142,5 @@ func TestReturnWithoutChangesWhenDynamicErrorMessageWithNoTemplates(t *testing.T
 
 	actual := renderErrorTemplate(tpl, res)
 
-	internal.Equal(t, tpl, actual)
+	assert.Equal(t, tpl, actual)
 }

--- a/https/authenticationGroup_test.go
+++ b/https/authenticationGroup_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apimatic/go-core-runtime/assert"
+	"github.com/apimatic/go-core-runtime/internal"
 )
 
 const API_KEY = "api-key"
@@ -99,7 +99,7 @@ func TestErrorWhenUndefinedAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError("authThatDoesntExist is undefined!"))
+	internal.EqualError(t, err, AuthenticationError("authThatDoesntExist is undefined!"))
 }
 
 func TestSuccessfulCallWhenHeaderAuth(t *testing.T) {
@@ -108,14 +108,14 @@ func TestSuccessfulCallWhenHeaderAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	header := httpContext.Request.Header
 
 	expected := MockHeaderToken
 	actual := header.Get("api-key")
 
-	assert.Equal(t, expected, actual)
+	internal.Equal(t, expected, actual)
 }
 
 func TestSuccessfulCallWhenQueryAuth(t *testing.T) {
@@ -124,14 +124,14 @@ func TestSuccessfulCallWhenQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	query := httpContext.Request.URL.Query()
 
 	expected := MockQueryToken
 	actual := query.Get("api-token")
 
-	assert.Equal(t, expected, actual)
+	internal.Equal(t, expected, actual)
 }
 
 func TestSuccessfulCallWhenHeaderAndQueryAuth(t *testing.T) {
@@ -145,13 +145,13 @@ func TestSuccessfulCallWhenHeaderAndQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
-	assert.Equal(t, MockHeaderToken, headerToken)
+	internal.Equal(t, MockHeaderToken, headerToken)
 
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
-	assert.Equal(t, MockQueryToken, queryToken)
+	internal.Equal(t, MockQueryToken, queryToken)
 }
 
 func TestSuccessfulCallWhenHeaderOrQueryAuth(t *testing.T) {
@@ -165,7 +165,7 @@ func TestSuccessfulCallWhenHeaderOrQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
@@ -188,13 +188,13 @@ func TestSuccessfulCallWhenEmptyHeaderOrQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
 
-	assert.Equal(t, "", headerToken)
-	assert.Equal(t, MockQueryToken, queryToken)
+	internal.Equal(t, "", headerToken)
+	internal.Equal(t, MockQueryToken, queryToken)
 }
 
 func TestSuccessfulCallWhenHeaderOrMissingQueryAuth(t *testing.T) {
@@ -208,14 +208,14 @@ func TestSuccessfulCallWhenHeaderOrMissingQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
 
-	assert.Equal(t, "", queryToken)
+	internal.Equal(t, "", queryToken)
 
-	assert.Equal(t, MockHeaderToken, headerToken)
+	internal.Equal(t, MockHeaderToken, headerToken)
 }
 
 func TestSuccessfulCallWhenMissingHeaderOrQueryAuth(t *testing.T) {
@@ -229,13 +229,13 @@ func TestSuccessfulCallWhenMissingHeaderOrQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
 
-	assert.Equal(t, "", headerToken)
-	assert.Equal(t, MockQueryToken, queryToken)
+	internal.Equal(t, "", headerToken)
+	internal.Equal(t, MockQueryToken, queryToken)
 }
 
 func TestErrorWhenHeaderWithEmptyValueAndQueryAuth(t *testing.T) {
@@ -249,7 +249,7 @@ func TestErrorWhenHeaderWithEmptyValueAndQueryAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR))
+	internal.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR))
 }
 
 func TestErrorWhenHeaderAndQueryWithEmptyValueAuth(t *testing.T) {
@@ -263,7 +263,7 @@ func TestErrorWhenHeaderAndQueryWithEmptyValueAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError(API_TOKEN_MISSING_ERROR))
+	internal.EqualError(t, err, AuthenticationError(API_TOKEN_MISSING_ERROR))
 }
 
 func TestErrorWhenHeaderAndMissingQueryAuth(t *testing.T) {
@@ -277,7 +277,7 @@ func TestErrorWhenHeaderAndMissingQueryAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError("missingQuery is undefined!"))
+	internal.EqualError(t, err, AuthenticationError("missingQuery is undefined!"))
 }
 
 func TestErrorWhenMissingHeaderAndQueryAuth(t *testing.T) {
@@ -291,7 +291,7 @@ func TestErrorWhenMissingHeaderAndQueryAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError("missingHeader is undefined!"))
+	internal.EqualError(t, err, AuthenticationError("missingHeader is undefined!"))
 }
 
 func TestErrorWhenHeaderOrQueryAuthBothAreMissing(t *testing.T) {
@@ -305,7 +305,7 @@ func TestErrorWhenHeaderOrQueryAuthBothAreMissing(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError("headerMissing is undefined!", "queryMissing is undefined!"))
+	internal.EqualError(t, err, AuthenticationError("headerMissing is undefined!", "queryMissing is undefined!"))
 }
 
 func TestErrorWhenHeaderOrQueryAuthBothAreEmpty(t *testing.T) {
@@ -319,5 +319,5 @@ func TestErrorWhenHeaderOrQueryAuthBothAreEmpty(t *testing.T) {
 
 	_, err := request.Call()
 
-	assert.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR, API_TOKEN_MISSING_ERROR))
+	internal.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR, API_TOKEN_MISSING_ERROR))
 }

--- a/https/authenticationGroup_test.go
+++ b/https/authenticationGroup_test.go
@@ -2,11 +2,10 @@ package https
 
 import (
 	"errors"
+	"github.com/apimatic/go-core-runtime/internal/assert"
 	"net/http"
 	"strings"
 	"testing"
-
-	"github.com/apimatic/go-core-runtime/internal"
 )
 
 const API_KEY = "api-key"
@@ -99,7 +98,7 @@ func TestErrorWhenUndefinedAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError("authThatDoesntExist is undefined!"))
+	assert.EqualError(t, err, AuthenticationError("authThatDoesntExist is undefined!"))
 }
 
 func TestSuccessfulCallWhenHeaderAuth(t *testing.T) {
@@ -108,14 +107,14 @@ func TestSuccessfulCallWhenHeaderAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	header := httpContext.Request.Header
 
 	expected := MockHeaderToken
 	actual := header.Get("api-key")
 
-	internal.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestSuccessfulCallWhenQueryAuth(t *testing.T) {
@@ -124,14 +123,14 @@ func TestSuccessfulCallWhenQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	query := httpContext.Request.URL.Query()
 
 	expected := MockQueryToken
 	actual := query.Get("api-token")
 
-	internal.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestSuccessfulCallWhenHeaderAndQueryAuth(t *testing.T) {
@@ -145,13 +144,13 @@ func TestSuccessfulCallWhenHeaderAndQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
-	internal.Equal(t, MockHeaderToken, headerToken)
+	assert.Equal(t, MockHeaderToken, headerToken)
 
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
-	internal.Equal(t, MockQueryToken, queryToken)
+	assert.Equal(t, MockQueryToken, queryToken)
 }
 
 func TestSuccessfulCallWhenHeaderOrQueryAuth(t *testing.T) {
@@ -165,7 +164,7 @@ func TestSuccessfulCallWhenHeaderOrQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
@@ -188,13 +187,13 @@ func TestSuccessfulCallWhenEmptyHeaderOrQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
 
-	internal.Equal(t, "", headerToken)
-	internal.Equal(t, MockQueryToken, queryToken)
+	assert.Equal(t, "", headerToken)
+	assert.Equal(t, MockQueryToken, queryToken)
 }
 
 func TestSuccessfulCallWhenHeaderOrMissingQueryAuth(t *testing.T) {
@@ -208,14 +207,14 @@ func TestSuccessfulCallWhenHeaderOrMissingQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
 
-	internal.Equal(t, "", queryToken)
+	assert.Equal(t, "", queryToken)
 
-	internal.Equal(t, MockHeaderToken, headerToken)
+	assert.Equal(t, MockHeaderToken, headerToken)
 }
 
 func TestSuccessfulCallWhenMissingHeaderOrQueryAuth(t *testing.T) {
@@ -229,13 +228,13 @@ func TestSuccessfulCallWhenMissingHeaderOrQueryAuth(t *testing.T) {
 
 	httpContext, err := request.Call()
 
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 
 	headerToken := httpContext.Request.Header.Get(API_KEY)
 	queryToken := httpContext.Request.URL.Query().Get(API_TOKEN)
 
-	internal.Equal(t, "", headerToken)
-	internal.Equal(t, MockQueryToken, queryToken)
+	assert.Equal(t, "", headerToken)
+	assert.Equal(t, MockQueryToken, queryToken)
 }
 
 func TestErrorWhenHeaderWithEmptyValueAndQueryAuth(t *testing.T) {
@@ -249,7 +248,7 @@ func TestErrorWhenHeaderWithEmptyValueAndQueryAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR))
+	assert.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR))
 }
 
 func TestErrorWhenHeaderAndQueryWithEmptyValueAuth(t *testing.T) {
@@ -263,7 +262,7 @@ func TestErrorWhenHeaderAndQueryWithEmptyValueAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError(API_TOKEN_MISSING_ERROR))
+	assert.EqualError(t, err, AuthenticationError(API_TOKEN_MISSING_ERROR))
 }
 
 func TestErrorWhenHeaderAndMissingQueryAuth(t *testing.T) {
@@ -277,7 +276,7 @@ func TestErrorWhenHeaderAndMissingQueryAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError("missingQuery is undefined!"))
+	assert.EqualError(t, err, AuthenticationError("missingQuery is undefined!"))
 }
 
 func TestErrorWhenMissingHeaderAndQueryAuth(t *testing.T) {
@@ -291,7 +290,7 @@ func TestErrorWhenMissingHeaderAndQueryAuth(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError("missingHeader is undefined!"))
+	assert.EqualError(t, err, AuthenticationError("missingHeader is undefined!"))
 }
 
 func TestErrorWhenHeaderOrQueryAuthBothAreMissing(t *testing.T) {
@@ -305,7 +304,7 @@ func TestErrorWhenHeaderOrQueryAuthBothAreMissing(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError("headerMissing is undefined!", "queryMissing is undefined!"))
+	assert.EqualError(t, err, AuthenticationError("headerMissing is undefined!", "queryMissing is undefined!"))
 }
 
 func TestErrorWhenHeaderOrQueryAuthBothAreEmpty(t *testing.T) {
@@ -319,5 +318,5 @@ func TestErrorWhenHeaderOrQueryAuthBothAreEmpty(t *testing.T) {
 
 	_, err := request.Call()
 
-	internal.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR, API_TOKEN_MISSING_ERROR))
+	assert.EqualError(t, err, AuthenticationError(API_KEY_MISSING_ERROR, API_TOKEN_MISSING_ERROR))
 }

--- a/https/callBuilder_test.go
+++ b/https/callBuilder_test.go
@@ -3,14 +3,13 @@ package https
 import (
 	"context"
 	"errors"
+	"github.com/apimatic/go-core-runtime/internal/assert"
 	"github.com/apimatic/go-core-runtime/logger"
 	"io"
 	"net/http"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/apimatic/go-core-runtime/internal"
 )
 
 var ctx = context.Background()
@@ -417,7 +416,7 @@ func TestError(t *testing.T) {
 
 			_, err := request.Call()
 
-			internal.ErrorContains(t, err, test.expected)
+			assert.ErrorContains(t, err, test.expected)
 		})
 	}
 }

--- a/https/callBuilder_test.go
+++ b/https/callBuilder_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apimatic/go-core-runtime/assert"
+	"github.com/apimatic/go-core-runtime/internal"
 )
 
 var ctx = context.Background()
@@ -417,7 +417,7 @@ func TestError(t *testing.T) {
 
 			_, err := request.Call()
 
-			assert.ErrorContains(t, err, test.expected)
+			internal.ErrorContains(t, err, test.expected)
 		})
 	}
 }

--- a/https/formData.go
+++ b/https/formData.go
@@ -191,8 +191,8 @@ func (fp *formParam) processSlice() (map[string][]string, error) {
 	result := make(map[string][]string)
 	for i := 0; i < reflectValue.Len(); i++ {
 		innerElem := reflectValue.Index(i)
-		indexStr := processElementIndex(innerElem, i)
-		innerKey := fp.arraySerializationOption.joinKey(fp.key, indexStr)
+		elemIndex := createElemIndex(innerElem, i)
+		innerKey := fp.arraySerializationOption.joinKey(fp.key, elemIndex)
 		innerParam := fp.clone(innerKey, innerElem.Interface())
 		innerFlatMap, err := innerParam.toMap()
 		if err != nil {
@@ -203,11 +203,14 @@ func (fp *formParam) processSlice() (map[string][]string, error) {
 	return result, nil
 }
 
-func processElementIndex(elem reflect.Value, index int) any {
+// creates index for enums and native types in slice
+func createElemIndex(elem reflect.Value, index int) any {
 	switch elem.Kind() {
+	// Case for handling enums of number and string types
 	case reflect.Int, reflect.String:
 		return nil
 	default:
+		// Interface of native types cannot be handled using reflect.Kind
 		switch elem.Interface().(type) {
 		case bool, int, int8, int16, int32, int64,
 			uint, uint8, uint16, uint32, uint64,

--- a/https/formData_test.go
+++ b/https/formData_test.go
@@ -1,6 +1,8 @@
 package https
 
 import (
+	"fmt"
+	"github.com/apimatic/go-core-runtime/internal"
 	"math"
 	"net/http"
 	"net/url"
@@ -117,6 +119,34 @@ func TestPrepareFormFieldsBoolSlice(t *testing.T) {
 	expected := result
 	expected.Add("param2", "false")
 	expected.Add("param2", "true")
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Failed:\nExpected: %v\nGot: %v", expected, result)
+	}
+}
+
+func TestPrepareFormFieldsEnumSlice(t *testing.T) {
+	stringEnums := []internal.MonthNameEnum{
+		internal.MonthNameEnum_JANUARY,
+		internal.MonthNameEnum_FEBRUARY,
+		internal.MonthNameEnum_MARCH,
+	}
+	numberEnums := []internal.MonthNumberEnum{
+		internal.MonthNumberEnum_JANUARY,
+		internal.MonthNumberEnum_FEBRUARY,
+		internal.MonthNumberEnum_MARCH,
+	}
+
+	params := formParams{
+		{"stringEnums", stringEnums, nil, Csv},
+		{"numberEnums", numberEnums, nil, Csv},
+	}
+	result := url.Values{}
+	_ = params.prepareFormFields(result)
+
+	expected := url.Values{}
+	expected.Add("stringEnums", fmt.Sprintf("%v,%v,%v", stringEnums[0], stringEnums[1], stringEnums[2]))
+	expected.Add("numberEnums", fmt.Sprintf("%v,%v,%v", numberEnums[0], numberEnums[1], numberEnums[2]))
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Failed:\nExpected: %v\nGot: %v", expected, result)

--- a/https/formData_test.go
+++ b/https/formData_test.go
@@ -125,6 +125,26 @@ func TestPrepareFormFieldsBoolSlice(t *testing.T) {
 	}
 }
 
+func TestPrepareFormFieldsAnySlice(t *testing.T) {
+	anySlice := []any{
+		any("Item1"),
+		any("Item2"),
+	}
+
+	params := formParams{
+		{"anySlice", anySlice, nil, Csv},
+	}
+	result := url.Values{}
+	_ = params.prepareFormFields(result)
+
+	expected := url.Values{}
+	expected.Add("anySlice", fmt.Sprintf("%v,%v", anySlice[0], anySlice[1]))
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Failed:\nExpected: %v\nGot: %v", expected, result)
+	}
+}
+
 func TestPrepareFormFieldsEnumSlice(t *testing.T) {
 	stringEnums := []internal.MonthNameEnum{
 		internal.MonthNameEnum_JANUARY,

--- a/internal/assert/assertions.go
+++ b/internal/assert/assertions.go
@@ -1,4 +1,4 @@
-package internal
+package assert
 
 import (
 	"bufio"

--- a/internal/assertions.go
+++ b/internal/assertions.go
@@ -1,4 +1,4 @@
-package assert
+package internal
 
 import (
 	"bufio"
@@ -179,7 +179,7 @@ func callerInfo() []string {
 		if len(parts) > 1 {
 			filename := parts[len(parts)-1]
 			dir := parts[len(parts)-2]
-			if (dir != "github.com/apimatic/go-core-runtime/assert" && dir != "mock" && dir != "require") || filename == "mock_test.go" {
+			if (dir != "github.com/apimatic/go-core-runtime/internal" && dir != "mock" && dir != "require") || filename == "mock_test.go" {
 				callers = append(callers, fmt.Sprintf("%s:%d", file, line))
 			}
 		}

--- a/internal/example_enums.go
+++ b/internal/example_enums.go
@@ -1,0 +1,39 @@
+package internal
+
+// MonthNameEnum is a string enum.
+// An enum representing the months of a year
+type MonthNameEnum string
+
+const (
+	MonthNameEnum_JANUARY   MonthNameEnum = "January"
+	MonthNameEnum_FEBRUARY  MonthNameEnum = "February"
+	MonthNameEnum_MARCH     MonthNameEnum = "March"
+	MonthNameEnum_APRIL     MonthNameEnum = "April"
+	MonthNameEnum_MAY       MonthNameEnum = "May"
+	MonthNameEnum_JUNE      MonthNameEnum = "June"
+	MonthNameEnum_JULY      MonthNameEnum = "July"
+	MonthNameEnum_AUGUST    MonthNameEnum = "August"
+	MonthNameEnum_SEPTEMBER MonthNameEnum = "September"
+	MonthNameEnum_OCTOBER   MonthNameEnum = "October"
+	MonthNameEnum_NOVEMBER  MonthNameEnum = "November"
+	MonthNameEnum_DECEMBER  MonthNameEnum = "December"
+)
+
+// MonthNumberEnum is a int enum.
+// An enum representing the months of a year
+type MonthNumberEnum int
+
+const (
+	MonthNumberEnum_JANUARY   MonthNumberEnum = 1
+	MonthNumberEnum_FEBRUARY  MonthNumberEnum = 2
+	MonthNumberEnum_MARCH     MonthNumberEnum = 3
+	MonthNumberEnum_APRIL     MonthNumberEnum = 4
+	MonthNumberEnum_MAY       MonthNumberEnum = 5
+	MonthNumberEnum_JUNE      MonthNumberEnum = 6
+	MonthNumberEnum_JULY      MonthNumberEnum = 7
+	MonthNumberEnum_AUGUST    MonthNumberEnum = 8
+	MonthNumberEnum_SEPTEMBER MonthNumberEnum = 9
+	MonthNumberEnum_OCTOBER   MonthNumberEnum = 10
+	MonthNumberEnum_NOVEMBER  MonthNumberEnum = 11
+	MonthNumberEnum_DECEMBER  MonthNumberEnum = 12
+)

--- a/utilities/apiHelper_test.go
+++ b/utilities/apiHelper_test.go
@@ -3,14 +3,13 @@ package utilities
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/apimatic/go-core-runtime/internal/assert"
 	"net/url"
 	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/apimatic/go-core-runtime/internal"
 )
 
 // NullableTimeToStringMap
@@ -661,7 +660,7 @@ func TestUpdateUserAgentAllArguments(t *testing.T) {
 	os := runtime.GOOS
 	engine := runtime.Version()
 	engineVer := strings.Replace(runtime.Version(), "go", "", 1)
-	internal.Equal(t, "userAgent "+os+" "+engine+" "+engineVer, result)
+	assert.Equal(t, "userAgent "+os+" "+engine+" "+engineVer, result)
 }
 
 func TestUpdateUserAgentEmptyArguments(t *testing.T) {
@@ -675,7 +674,7 @@ func TestUpdateUserAgent2Arguments(t *testing.T) {
 	result := UpdateUserAgent("userAgent {os-info} {engine}")
 	os := runtime.GOOS
 	engine := runtime.Version()
-	internal.Equal(t, "userAgent "+os+" "+engine, result)
+	assert.Equal(t, "userAgent "+os+" "+engine, result)
 }
 
 func TestUpdateUserAgentWrongArguments(t *testing.T) {

--- a/utilities/apiHelper_test.go
+++ b/utilities/apiHelper_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apimatic/go-core-runtime/assert"
+	"github.com/apimatic/go-core-runtime/internal"
 )
 
 // NullableTimeToStringMap
@@ -661,7 +661,7 @@ func TestUpdateUserAgentAllArguments(t *testing.T) {
 	os := runtime.GOOS
 	engine := runtime.Version()
 	engineVer := strings.Replace(runtime.Version(), "go", "", 1)
-	assert.Equal(t, "userAgent "+os+" "+engine+" "+engineVer, result)
+	internal.Equal(t, "userAgent "+os+" "+engine+" "+engineVer, result)
 }
 
 func TestUpdateUserAgentEmptyArguments(t *testing.T) {
@@ -675,7 +675,7 @@ func TestUpdateUserAgent2Arguments(t *testing.T) {
 	result := UpdateUserAgent("userAgent {os-info} {engine}")
 	os := runtime.GOOS
 	engine := runtime.Version()
-	assert.Equal(t, "userAgent "+os+" "+engine, result)
+	internal.Equal(t, "userAgent "+os+" "+engine, result)
 }
 
 func TestUpdateUserAgentWrongArguments(t *testing.T) {

--- a/utilities/internal_time_types_test.go
+++ b/utilities/internal_time_types_test.go
@@ -2,16 +2,15 @@ package utilities
 
 import (
 	"encoding/json"
+	"github.com/apimatic/go-core-runtime/internal/assert"
 	"testing"
 	"time"
-
-	"github.com/apimatic/go-core-runtime/internal"
 )
 
 func TestUnixDateTimeString(t *testing.T) {
 	newTime := time.Unix(1484719381, 0)
 	unixDateTime := NewUnixDateTime(newTime)
-	internal.Equal(t, "1484719381", unixDateTime.String())
+	assert.Equal(t, "1484719381", unixDateTime.String())
 }
 
 func TestUnixDateTime(t *testing.T) {
@@ -19,117 +18,117 @@ func TestUnixDateTime(t *testing.T) {
 	unixDateTime := NewUnixDateTime(newTime)
 
 	bytes, err := json.Marshal(unixDateTime)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	var newUnixDateTime UnixDateTime
 	err = json.Unmarshal(bytes, &newUnixDateTime)
-	internal.NoError(t, err)
-	internal.Equal(t, newTime, newUnixDateTime.Value())
+	assert.NoError(t, err)
+	assert.Equal(t, newTime, newUnixDateTime.Value())
 }
 
 func TestUnixDateTimeError(t *testing.T) {
 	var newUnixDateTime UnixDateTime
 	err := json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newUnixDateTime)
-	internal.EqualError(t, err, "json: cannot unmarshal string into Go value of type int64")
+	assert.EqualError(t, err, "json: cannot unmarshal string into Go value of type int64")
 }
 
 func TestDefaultTimeString(t *testing.T) {
 	newTime, err := time.Parse(DEFAULT_DATE, "1994-02-13")
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	defaultTime := NewDefaultTime(newTime)
-	internal.Equal(t, "1994-02-13", defaultTime.String())
+	assert.Equal(t, "1994-02-13", defaultTime.String())
 }
 
 func TestDefaultTime(t *testing.T) {
 	newTime, err := time.Parse(DEFAULT_DATE, "1994-02-13")
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	defaultTime := NewDefaultTime(newTime)
 
 	bytes, err := json.Marshal(defaultTime)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	var newDefaultTime DefaultTime
 	err = json.Unmarshal(bytes, &newDefaultTime)
-	internal.NoError(t, err)
-	internal.Equal(t, newTime, newDefaultTime.Value())
+	assert.NoError(t, err)
+	assert.Equal(t, newTime, newDefaultTime.Value())
 }
 
 func TestDefaultTimeError1(t *testing.T) {
 	var newDefaultTime DefaultTime
 	err := json.Unmarshal([]byte(`1484719381`), &newDefaultTime)
-	internal.EqualError(t, err, "json: cannot unmarshal number into Go value of type string")
+	assert.EqualError(t, err, "json: cannot unmarshal number into Go value of type string")
 }
 
 func TestDefaultTimeError2(t *testing.T) {
 	var newDefaultTime DefaultTime
 	err := json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newDefaultTime)
-	internal.EqualError(t, err, "parsing time \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006-01-02\": cannot parse \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006\"")
+	assert.EqualError(t, err, "parsing time \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006-01-02\": cannot parse \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006\"")
 }
 
 func TestRFC3339TimeString(t *testing.T) {
 	newTime, err := time.Parse(time.RFC3339Nano, "1994-02-13T14:01:54.9571247Z")
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	rFC3339Time := NewRFC3339Time(newTime)
-	internal.Equal(t, "1994-02-13T14:01:54.9571247Z", rFC3339Time.String())
+	assert.Equal(t, "1994-02-13T14:01:54.9571247Z", rFC3339Time.String())
 }
 
 func TestRFC3339Time(t *testing.T) {
 	newTime, err := time.Parse(time.RFC3339Nano, "1994-02-13T14:01:54.9571247Z")
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	rFC3339Time := NewRFC3339Time(newTime)
 
 	bytes, err := json.Marshal(rFC3339Time)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	var newRFC3339Time RFC3339Time
 	err = json.Unmarshal(bytes, &newRFC3339Time)
-	internal.NoError(t, err)
-	internal.Equal(t, newTime, newRFC3339Time.Value())
+	assert.NoError(t, err)
+	assert.Equal(t, newTime, newRFC3339Time.Value())
 }
 
 func TestRFC1123TimeString(t *testing.T) {
 	newTime, err := time.Parse(time.RFC1123, "Sun, 06 Nov 1994 08:49:37 GMT")
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	rFC1123Time := NewRFC1123Time(newTime)
-	internal.Equal(t, "Sun, 06 Nov 1994 08:49:37 GMT", rFC1123Time.String())
+	assert.Equal(t, "Sun, 06 Nov 1994 08:49:37 GMT", rFC1123Time.String())
 }
 
 func TestRFC1123Time(t *testing.T) {
 	newTime, err := time.Parse(time.RFC1123, "Sun, 06 Nov 1994 08:49:37 GMT")
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	rFC1123Time := NewRFC1123Time(newTime)
 
 	bytes, err := json.Marshal(rFC1123Time)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	var newRFC1123Time RFC1123Time
 	err = json.Unmarshal(bytes, &newRFC1123Time)
-	internal.NoError(t, err)
-	internal.Equal(t, newTime, rFC1123Time.Value())
+	assert.NoError(t, err)
+	assert.Equal(t, newTime, rFC1123Time.Value())
 }
 
 func TestObjSliceToTimeSlice(t *testing.T) {
 	initialBytes := []byte(`["Sun, 06 Nov 1994 08:49:37 GMT","Sun, 06 Nov 1994 08:49:37 GMT"]`)
 	var strArray []string
 	err := json.Unmarshal(initialBytes, &strArray)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	timeArray, err := ToTimeSlice(strArray, time.RFC1123)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	newObjArray := TimeSliceToObjSlice[RFC1123Time](timeArray)
 	newTimeArray := ObjSliceToTimeSlice(newObjArray)
 	newStrArray := TimeToStringSlice(newTimeArray, time.RFC1123)
 	resultBytes, err := json.Marshal(newStrArray)
-	internal.NoError(t, err)
-	internal.Equal(t, string(initialBytes), string(resultBytes))
+	assert.NoError(t, err)
+	assert.Equal(t, string(initialBytes), string(resultBytes))
 }
 
 func TestObjMapToTimeMap(t *testing.T) {
 	initialBytes := []byte(`{"key1":"Sun, 06 Nov 1994 08:49:37 GMT","key2":"Sun, 06 Nov 1994 08:49:37 GMT"}`)
 	var strMap map[string]string
 	err := json.Unmarshal(initialBytes, &strMap)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	timeMap, err := ToTimeMap(strMap, time.RFC1123)
-	internal.NoError(t, err)
+	assert.NoError(t, err)
 	newObjMap := TimeMapToObjMap[RFC1123Time](timeMap)
 	newTimeMap := ObjMapToTimeMap(newObjMap)
 	newStrMap := TimeToStringMap(newTimeMap, time.RFC1123)
 	resultBytes, err := json.Marshal(newStrMap)
-	internal.NoError(t, err)
-	internal.Equal(t, string(initialBytes), string(resultBytes))
+	assert.NoError(t, err)
+	assert.Equal(t, string(initialBytes), string(resultBytes))
 }

--- a/utilities/internal_time_types_test.go
+++ b/utilities/internal_time_types_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apimatic/go-core-runtime/assert"
+	"github.com/apimatic/go-core-runtime/internal"
 )
 
 func TestUnixDateTimeString(t *testing.T) {
 	newTime := time.Unix(1484719381, 0)
 	unixDateTime := NewUnixDateTime(newTime)
-	assert.Equal(t, "1484719381", unixDateTime.String())
+	internal.Equal(t, "1484719381", unixDateTime.String())
 }
 
 func TestUnixDateTime(t *testing.T) {
@@ -19,117 +19,117 @@ func TestUnixDateTime(t *testing.T) {
 	unixDateTime := NewUnixDateTime(newTime)
 
 	bytes, err := json.Marshal(unixDateTime)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	var newUnixDateTime UnixDateTime
 	err = json.Unmarshal(bytes, &newUnixDateTime)
-	assert.NoError(t, err)
-	assert.Equal(t, newTime, newUnixDateTime.Value())
+	internal.NoError(t, err)
+	internal.Equal(t, newTime, newUnixDateTime.Value())
 }
 
 func TestUnixDateTimeError(t *testing.T) {
 	var newUnixDateTime UnixDateTime
 	err := json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newUnixDateTime)
-	assert.EqualError(t, err, "json: cannot unmarshal string into Go value of type int64")
+	internal.EqualError(t, err, "json: cannot unmarshal string into Go value of type int64")
 }
 
 func TestDefaultTimeString(t *testing.T) {
 	newTime, err := time.Parse(DEFAULT_DATE, "1994-02-13")
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	defaultTime := NewDefaultTime(newTime)
-	assert.Equal(t, "1994-02-13", defaultTime.String())
+	internal.Equal(t, "1994-02-13", defaultTime.String())
 }
 
 func TestDefaultTime(t *testing.T) {
 	newTime, err := time.Parse(DEFAULT_DATE, "1994-02-13")
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	defaultTime := NewDefaultTime(newTime)
 
 	bytes, err := json.Marshal(defaultTime)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	var newDefaultTime DefaultTime
 	err = json.Unmarshal(bytes, &newDefaultTime)
-	assert.NoError(t, err)
-	assert.Equal(t, newTime, newDefaultTime.Value())
+	internal.NoError(t, err)
+	internal.Equal(t, newTime, newDefaultTime.Value())
 }
 
 func TestDefaultTimeError1(t *testing.T) {
 	var newDefaultTime DefaultTime
 	err := json.Unmarshal([]byte(`1484719381`), &newDefaultTime)
-	assert.EqualError(t, err, "json: cannot unmarshal number into Go value of type string")
+	internal.EqualError(t, err, "json: cannot unmarshal number into Go value of type string")
 }
 
 func TestDefaultTimeError2(t *testing.T) {
 	var newDefaultTime DefaultTime
 	err := json.Unmarshal([]byte(`"Sun, 06 Nov 1994 08:49:37 GMT"`), &newDefaultTime)
-	assert.EqualError(t, err, "parsing time \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006-01-02\": cannot parse \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006\"")
+	internal.EqualError(t, err, "parsing time \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006-01-02\": cannot parse \"Sun, 06 Nov 1994 08:49:37 GMT\" as \"2006\"")
 }
 
 func TestRFC3339TimeString(t *testing.T) {
 	newTime, err := time.Parse(time.RFC3339Nano, "1994-02-13T14:01:54.9571247Z")
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	rFC3339Time := NewRFC3339Time(newTime)
-	assert.Equal(t, "1994-02-13T14:01:54.9571247Z", rFC3339Time.String())
+	internal.Equal(t, "1994-02-13T14:01:54.9571247Z", rFC3339Time.String())
 }
 
 func TestRFC3339Time(t *testing.T) {
 	newTime, err := time.Parse(time.RFC3339Nano, "1994-02-13T14:01:54.9571247Z")
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	rFC3339Time := NewRFC3339Time(newTime)
 
 	bytes, err := json.Marshal(rFC3339Time)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	var newRFC3339Time RFC3339Time
 	err = json.Unmarshal(bytes, &newRFC3339Time)
-	assert.NoError(t, err)
-	assert.Equal(t, newTime, newRFC3339Time.Value())
+	internal.NoError(t, err)
+	internal.Equal(t, newTime, newRFC3339Time.Value())
 }
 
 func TestRFC1123TimeString(t *testing.T) {
 	newTime, err := time.Parse(time.RFC1123, "Sun, 06 Nov 1994 08:49:37 GMT")
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	rFC1123Time := NewRFC1123Time(newTime)
-	assert.Equal(t, "Sun, 06 Nov 1994 08:49:37 GMT", rFC1123Time.String())
+	internal.Equal(t, "Sun, 06 Nov 1994 08:49:37 GMT", rFC1123Time.String())
 }
 
 func TestRFC1123Time(t *testing.T) {
 	newTime, err := time.Parse(time.RFC1123, "Sun, 06 Nov 1994 08:49:37 GMT")
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	rFC1123Time := NewRFC1123Time(newTime)
 
 	bytes, err := json.Marshal(rFC1123Time)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	var newRFC1123Time RFC1123Time
 	err = json.Unmarshal(bytes, &newRFC1123Time)
-	assert.NoError(t, err)
-	assert.Equal(t, newTime, rFC1123Time.Value())
+	internal.NoError(t, err)
+	internal.Equal(t, newTime, rFC1123Time.Value())
 }
 
 func TestObjSliceToTimeSlice(t *testing.T) {
 	initialBytes := []byte(`["Sun, 06 Nov 1994 08:49:37 GMT","Sun, 06 Nov 1994 08:49:37 GMT"]`)
 	var strArray []string
 	err := json.Unmarshal(initialBytes, &strArray)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	timeArray, err := ToTimeSlice(strArray, time.RFC1123)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	newObjArray := TimeSliceToObjSlice[RFC1123Time](timeArray)
 	newTimeArray := ObjSliceToTimeSlice(newObjArray)
 	newStrArray := TimeToStringSlice(newTimeArray, time.RFC1123)
 	resultBytes, err := json.Marshal(newStrArray)
-	assert.NoError(t, err)
-	assert.Equal(t, string(initialBytes), string(resultBytes))
+	internal.NoError(t, err)
+	internal.Equal(t, string(initialBytes), string(resultBytes))
 }
 
 func TestObjMapToTimeMap(t *testing.T) {
 	initialBytes := []byte(`{"key1":"Sun, 06 Nov 1994 08:49:37 GMT","key2":"Sun, 06 Nov 1994 08:49:37 GMT"}`)
 	var strMap map[string]string
 	err := json.Unmarshal(initialBytes, &strMap)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	timeMap, err := ToTimeMap(strMap, time.RFC1123)
-	assert.NoError(t, err)
+	internal.NoError(t, err)
 	newObjMap := TimeMapToObjMap[RFC1123Time](timeMap)
 	newTimeMap := ObjMapToTimeMap(newObjMap)
 	newStrMap := TimeToStringMap(newTimeMap, time.RFC1123)
 	resultBytes, err := json.Marshal(newStrMap)
-	assert.NoError(t, err)
-	assert.Equal(t, string(initialBytes), string(resultBytes))
+	internal.NoError(t, err)
+	internal.Equal(t, string(initialBytes), string(resultBytes))
 }

--- a/utilities/unionTypeHelper_test.go
+++ b/utilities/unionTypeHelper_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/apimatic/go-core-runtime/assert"
+	"github.com/apimatic/go-core-runtime/internal"
 )
 
 type UnionTypeCase struct {
@@ -22,19 +22,19 @@ type UnionTypeCase struct {
 
 func (u *UnionTypeCase) Assert(t *testing.T, result any, err error, anyTypeHolderSelected bool) {
 	if u.shouldFail {
-		assert.Nil(t, result)
-		assert.False(t, anyTypeHolderSelected)
-		assert.EqualError(t, err, u.expectedErrorMessage)
+		internal.Nil(t, result)
+		internal.False(t, anyTypeHolderSelected)
+		internal.EqualError(t, err, u.expectedErrorMessage)
 		return
 	}
-	assert.Nil(t, err)
-	assert.True(t, anyTypeHolderSelected)
-	assert.IsType(t, u.expectedType, result)
+	internal.Nil(t, err)
+	internal.True(t, anyTypeHolderSelected)
+	internal.IsType(t, u.expectedType, result)
 	marshalled, _ := json.Marshal(result)
 	if u.expectedValue == "" {
 		u.expectedValue = u.testValue
 	}
-	assert.Equal(t, u.expectedValue, string(marshalled))
+	internal.Equal(t, u.expectedValue, string(marshalled))
 }
 
 func TestCommonOneOfAndAnyOfCases(t *testing.T) {

--- a/utilities/unionTypeHelper_test.go
+++ b/utilities/unionTypeHelper_test.go
@@ -2,9 +2,8 @@ package utilities
 
 import (
 	"encoding/json"
+	"github.com/apimatic/go-core-runtime/internal/assert"
 	"testing"
-
-	"github.com/apimatic/go-core-runtime/internal"
 )
 
 type UnionTypeCase struct {
@@ -22,19 +21,19 @@ type UnionTypeCase struct {
 
 func (u *UnionTypeCase) Assert(t *testing.T, result any, err error, anyTypeHolderSelected bool) {
 	if u.shouldFail {
-		internal.Nil(t, result)
-		internal.False(t, anyTypeHolderSelected)
-		internal.EqualError(t, err, u.expectedErrorMessage)
+		assert.Nil(t, result)
+		assert.False(t, anyTypeHolderSelected)
+		assert.EqualError(t, err, u.expectedErrorMessage)
 		return
 	}
-	internal.Nil(t, err)
-	internal.True(t, anyTypeHolderSelected)
-	internal.IsType(t, u.expectedType, result)
+	assert.Nil(t, err)
+	assert.True(t, anyTypeHolderSelected)
+	assert.IsType(t, u.expectedType, result)
 	marshalled, _ := json.Marshal(result)
 	if u.expectedValue == "" {
 		u.expectedValue = u.testValue
 	}
-	internal.Equal(t, u.expectedValue, string(marshalled))
+	assert.Equal(t, u.expectedValue, string(marshalled))
 }
 
 func TestCommonOneOfAndAnyOfCases(t *testing.T) {


### PR DESCRIPTION
## What
This PR contains changes to fix the query parameters of type Enum array to serialized in CSV format.

## Why
These changes are made to fix the bug reported by our customer.
Closes #82 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
No breaking changes are introduced.

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
