### PR TITLE
fix(go): custom error casting  results in updating the Response object

### DIFF
--- a/https/callBuilder.go
+++ b/https/callBuilder.go
@@ -676,8 +676,7 @@ func (cb *defaultCallBuilder) CallAsJson() (*json.Decoder, *http.Response, error
 		if result.Response.Body == http.NoBody {
 			return nil, result.Response, fmt.Errorf("response body empty")
 		}
-		bodyBytes, err := io.ReadAll(result.Response.Body)
-		result.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		bodyBytes, err := result.GetResponseBody()
 		return json.NewDecoder(io.NopCloser(bytes.NewBuffer(bodyBytes))), result.Response, err
 	}
 	return nil, result.Response, err
@@ -696,11 +695,10 @@ func (cb *defaultCallBuilder) CallAsText() (string, *http.Response, error) {
 			return "", result.Response, fmt.Errorf("response body empty")
 		}
 
-		bodyBytes, err := io.ReadAll(result.Response.Body)
+		bodyBytes, err := result.GetResponseBody()
 		if err != nil {
 			return "", result.Response, fmt.Errorf("error reading Response body: %v", err.Error())
 		}
-		result.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		return string(bodyBytes), result.Response, err
 	}
 	return "", result.Response, err
@@ -719,7 +717,7 @@ func (cb *defaultCallBuilder) CallAsStream() ([]byte, *http.Response, error) {
 			return nil, result.Response, fmt.Errorf("response body empty")
 		}
 
-		bytes, err := io.ReadAll(result.Response.Body)
+		bytes, err := result.GetResponseBody()
 		if err != nil {
 			return nil, result.Response, fmt.Errorf("error reading Response body: %v", err.Error())
 		}

--- a/https/httpContext.go
+++ b/https/httpContext.go
@@ -1,6 +1,8 @@
 package https
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 )
 
@@ -14,4 +16,10 @@ func AddQuery(req *http.Request, key, value string) {
 	queryVal := req.URL.Query()
 	queryVal.Add(key, value)
 	req.URL.RawQuery = encodeSpace(queryVal.Encode())
+}
+
+func (ctx *HttpContext) GetResponseBody() ([]byte, error) {
+	bodyBytes, err := io.ReadAll(ctx.Response.Body)
+	ctx.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	return bodyBytes, err
 }

--- a/https/httpContext_test.go
+++ b/https/httpContext_test.go
@@ -1,0 +1,38 @@
+package https
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestAddQuery(t *testing.T) {
+
+	callBuilder := GetCallBuilder(ctx, "GET", "", nil)
+	request, err := callBuilder.toRequest()
+	AddQuery(request, "param", "query")
+
+	if request.URL.RawQuery != "param=query" || err != nil {
+		t.Errorf("Failed:\nExpected query param missing")
+	}
+}
+
+func TestGetResponseBody(t *testing.T) {
+	bodyBytes := []byte(`{"invalidJson"}`)
+	respBody := io.NopCloser(bytes.NewReader(bodyBytes))
+	ctx := HttpContext{
+		Response: &http.Response{
+			Body: respBody,
+		},
+	}
+
+	newBodyBytes, err := ctx.GetResponseBody()
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(newBodyBytes, bodyBytes) {
+		t.Errorf("Failed:\nExpected: %v\nGot: %v", bodyBytes, newBodyBytes)
+	}
+}


### PR DESCRIPTION
## What
Write a summary of the changes made in the PR.
This PR addresses an issue where the response body data was lost during the conversion of an error object to a custom error object, resulting in an empty response body.
## Why
Explain the reasons for the changes.
While converting the error object to a Custom error object Response Body data bytes were lost. And did not get a response body in response.
Closes #86 
## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [x] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
No breaking changes are introduced.

## Testing
New unit tests are added.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
