### PR TITLE
feat(go): add typed additional properties implementation

### DIFF
--- a/https/callBuilder.go
+++ b/https/callBuilder.go
@@ -670,7 +670,10 @@ func (cb *defaultCallBuilder) CallAsJson() (*json.Decoder, *http.Response, error
 	cb.InterceptRequest(f)
 	result, err := cb.Call()
 	if err != nil {
-		return nil, result.Response, err
+		if result != nil {
+			return nil, result.Response, err
+		}
+		return nil, &http.Response{}, err
 	}
 
 	if result.Response != nil {

--- a/utilities/additionalProperties.go
+++ b/utilities/additionalProperties.go
@@ -1,34 +1,68 @@
 package utilities
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
 
-// MapAdditionalProperties append additional properties to destination struct map
-func MapAdditionalProperties(destinationMap additionalProperties, sourceMap additionalProperties) {
-	destinationMap.appendMap(sourceMap)
+func ValidateAdditionalProperty[T any](dstMap map[string]T, keysToRemove ...string) error {
+	containsKey := func(key string) bool {
+		for _, tag := range keysToRemove {
+			if tag == key {
+				return true
+			}
+		}
+		return false
+	}
+
+	for key, _ := range dstMap {
+		if strings.TrimSpace(key) == "" {
+			return errors.New("an additional property key can not be empty or whitespace")
+		}
+		if containsKey(key) {
+			return errors.New("an additional property key, '" + key + "' conflicts with one of the model's properties")
+		}
+	}
+	return nil
 }
 
-// UnmarshalAdditionalProperties unmarshals additional properties and remove fields that exists on parent struct
-func UnmarshalAdditionalProperties(input []byte, keysToRemove ...string) (map[string]any, error) {
-	var destinationMap additionalProperties
+// MapAdditionalProperties append additional properties to destination struct map
+var MapAdditionalProperties = MapAdditionalProperty[any]
+
+// MapAdditionalProperty append additional properties to destination struct map
+func MapAdditionalProperty[T any](destinationMap additionalProperties[any], sourceMap additionalProperties[T]) {
+	for key, value := range sourceMap {
+		destinationMap[key] = value
+	}
+}
+
+// UnmarshalAdditionalProperties unmarshal additional properties and remove fields that exists on parent struct
+var UnmarshalAdditionalProperties = UnmarshalAdditionalProperty[any]
+
+// UnmarshalAdditionalProperty unmarshal additional properties and remove fields that exists on parent struct
+func UnmarshalAdditionalProperty[T any](input []byte, keysToRemove ...string) (map[string]T, error) {
+	destinationMap := additionalProperties[T]{}
 	err := destinationMap.unmarshalAdditionalProperties(input, keysToRemove)
 	return destinationMap, err
 }
 
 // additionalProperties helper struct for handling additional properties in models
-type additionalProperties map[string]any
+type additionalProperties[T any] map[string]T
 
-func (dstMap *additionalProperties) appendMap(srcMap additionalProperties) {
-	for key, value := range srcMap {
-		(*dstMap)[key] = value
-	}
-}
-
-func (dstMap *additionalProperties) unmarshalAdditionalProperties(input []byte, keysToRemove []string) error {
-	if err := json.Unmarshal(input, &dstMap); err != nil {
+func (srcMap *additionalProperties[T]) unmarshalAdditionalProperties(input []byte, keysToRemove []string) error {
+	var dstRawMap map[string]json.RawMessage
+	if err := json.Unmarshal(input, &dstRawMap); err != nil {
 		return err
 	}
 	for _, key := range keysToRemove {
-		delete(*dstMap, key)
+		delete(dstRawMap, key)
+	}
+	for key, value := range dstRawMap {
+		var typedVal T
+		if err := json.Unmarshal(value, &typedVal); err == nil {
+			(*srcMap)[key] = typedVal
+		}
 	}
 	return nil
 }

--- a/utilities/any_of_number_boolean.go
+++ b/utilities/any_of_number_boolean.go
@@ -1,0 +1,91 @@
+package utilities
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// AnyOfNumberVehicle represents a AnyOfNumberVehicle struct.
+// This is a container for any-of cases.
+type AnyOfNumberVehicle struct {
+	value     any
+	isNumber  bool
+	isVehicle bool
+}
+
+// String converts the AnyOfNumberVehicle object to a string representation.
+func (s AnyOfNumberVehicle) String() string {
+	if bytes, err := json.Marshal(s.value); err == nil {
+		return strings.Trim(string(bytes), "\"")
+	}
+	return ""
+}
+
+// MarshalJSON implements the json.Marshaler interface for AnyOfNumberVehicle.
+// It customizes the JSON marshaling process for AnyOfNumberVehicle objects.
+func (s AnyOfNumberVehicle) MarshalJSON() (
+	[]byte,
+	error) {
+	if s.value == nil {
+		return nil, errors.New("No underlying type is set. Please use any of the `models.AnyOfNumberBooleanContainer.From*` functions to initialize the AnyOfNumberVehicle object.")
+	}
+	return json.Marshal(s.toMap())
+}
+
+// toMap converts the AnyOfNumberVehicle object to a map representation for JSON marshaling.
+func (s AnyOfNumberVehicle) toMap() any {
+	switch obj := s.value.(type) {
+	case *int:
+		return *obj
+	case *Vehicle[bool]:
+		return obj.toMap()
+	}
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for AnyOfNumberVehicle.
+// It customizes the JSON unmarshaling process for AnyOfNumberVehicle objects.
+func (s *AnyOfNumberVehicle) UnmarshalJSON(input []byte) error {
+	result, err := UnmarshallAnyOf(input,
+		NewTypeHolder(new(int), false, &s.isNumber),
+		NewTypeHolder(&Vehicle[bool]{}, false, &s.isVehicle),
+	)
+
+	s.value = result
+	return err
+}
+
+func (s *AnyOfNumberVehicle) AsNumber() (
+	*int,
+	bool) {
+	if !s.isNumber {
+		return nil, false
+	}
+	return s.value.(*int), true
+}
+
+func (s *AnyOfNumberVehicle) AsVehicle() (
+	*Vehicle[bool],
+	bool) {
+	if !s.isVehicle {
+		return nil, false
+	}
+	return s.value.(*Vehicle[bool]), true
+}
+
+// internalAnyOfNumberBoolean represents a AnyOfNumberVehicle struct.
+// This is a container for any-of cases.
+type internalAnyOfNumberBoolean struct{}
+
+var AnyOfNumberBooleanContainer internalAnyOfNumberBoolean
+
+// The internalAnyOfNumberBoolean instance, wrapping the provided int value.
+func (s *internalAnyOfNumberBoolean) FromNumber(val int) AnyOfNumberVehicle {
+	return AnyOfNumberVehicle{value: &val}
+}
+
+// The internalAnyOfNumberBoolean instance, wrapping the provided bool value.
+func (s *internalAnyOfNumberBoolean) FromVehicle(val Vehicle[bool]) AnyOfNumberVehicle {
+	return AnyOfNumberVehicle{value: &val}
+}

--- a/utilities/internal_vehicle.go
+++ b/utilities/internal_vehicle.go
@@ -1,0 +1,83 @@
+package utilities
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+func ToPointer[T any](value T) *T {
+	return &value
+}
+
+type Vehicle[T any] struct {
+	Year                 int          `json:"year"`
+	Make                 *string      `json:"make"`
+	Model                *string      `json:"model"`
+	AdditionalProperties map[string]T `json:"_"`
+}
+
+func (v Vehicle[T]) MarshalJSON() (
+	[]byte,
+	error) {
+	if err := ValidateAdditionalProperty(v.AdditionalProperties,
+		"year", "make", "model"); err != nil {
+		return nil, err
+	}
+	return json.Marshal(v.toMap())
+}
+
+func (v Vehicle[T]) toMap() map[string]any {
+	structMap := make(map[string]any)
+	MapAdditionalProperty(structMap, v.AdditionalProperties)
+	if v.Make != nil {
+		structMap["make"] = *v.Make
+	} else {
+		structMap["make"] = "ferrari"
+	}
+	if v.Model != nil {
+		structMap["model"] = *v.Model
+	} else {
+		structMap["model"] = "MONZA SP2"
+	}
+	structMap["year"] = v.Year
+	return structMap
+}
+
+func (v *Vehicle[T]) UnmarshalJSON(input []byte) error {
+	var temp tempVehicle
+	err := json.Unmarshal(input, &temp)
+	if err != nil {
+		return NewMarshalError("Vehicle", err)
+	}
+	err = temp.validate()
+	if err != nil {
+		return err
+	}
+	additionalProperties, err := UnmarshalAdditionalProperty[T](input, "year", "make", "model")
+	if err != nil {
+		return err
+	}
+	v.AdditionalProperties = additionalProperties
+	v.Year = *temp.Year
+	v.Make = temp.Make
+	v.Model = temp.Model
+	return nil
+}
+
+type tempVehicle struct {
+	Year  *int    `json:"year"`
+	Make  *string `json:"make"`
+	Model *string `json:"model"`
+}
+
+func (c *tempVehicle) validate() error {
+	var errs []string
+	if c.Year == nil {
+		errs = append(errs, "required field `Year` is missing")
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return NewMarshalError("Vehicle", errors.New(strings.Join(errs, "\n\t=> ")))
+}

--- a/utilities/typed_additionalProperties_test.go
+++ b/utilities/typed_additionalProperties_test.go
@@ -1,0 +1,162 @@
+package utilities
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func Test_Float64Vehicle(t *testing.T) {
+	// Creating an instance of Vehicle
+	testObj := Vehicle[float64]{
+		Year:  2022,
+		Make:  ToPointer("Porsche"),
+		Model: ToPointer("Taycan turbo GT"),
+		AdditionalProperties: map[string]float64{
+			"top_speed":                 290,
+			"Electric range (BEV, ECE)": 605,
+			"Acceleration 0 - 100 km/h": 2.3,
+		},
+	}
+	// Serializing testObj to JSON
+	if serializedObject, err := json.Marshal(testObj); err != nil {
+		t.Error(err)
+	} else {
+		fmt.Printf("serializedObject: %v\n", string(serializedObject))
+	}
+
+	// JSON string to be deserialized
+	jsonString := `{"make":"Porsche", "model":"Taycan turbo GT", "year":2022, "top_speed":290, "Acceleration 0 - 100 km/h":2.3, "Electric range (BEV, ECE)":605, "battery energy": "97.0"}`
+
+	var deserializedObject Vehicle[float64]
+	// Deserializing JSON string to struct
+	if err := json.Unmarshal([]byte(jsonString), &deserializedObject); err != nil {
+		t.Error(err)
+	}
+
+	// Verifying if the deserialized object matches the original
+	if !reflect.DeepEqual(testObj, deserializedObject) {
+		t.Error("Test_Float64_Vehicle struct failed.")
+	}
+}
+
+func Test_Float64VehicleWhiteSpace(t *testing.T) {
+	// Creating an instance of Vehicle with a whitespace key
+	testObj := Vehicle[float64]{
+		Year:  2022,
+		Make:  ToPointer("Porsche"),
+		Model: ToPointer("Taycan turbo GT"),
+		AdditionalProperties: map[string]float64{
+			"      ": 528,
+		},
+	}
+
+	// Serializing testObj to JSON
+	if _, err := json.Marshal(testObj); err != nil {
+		fmt.Println(err)
+	} else {
+		t.Error("Test_Float64_Vehicle for WhiteSpace")
+	}
+}
+
+func Test_Float64VehicleConflict(t *testing.T) {
+	// Creating an instance of Vehicle with a conflicting key
+	testObj := Vehicle[float64]{
+		Year:  2022,
+		Make:  ToPointer("Porsche"),
+		Model: ToPointer("Taycan turbo GT"),
+		AdditionalProperties: map[string]float64{
+			"year": 2024,
+		},
+	}
+	// Serializing testObj to JSON
+	if _, err := json.Marshal(testObj); err != nil {
+		fmt.Println(err)
+	} else {
+		t.Error("Test_Float64_Vehicle for Conflict")
+	}
+}
+
+func Test_BikeVehicle(t *testing.T) {
+	// Creating an instance of Vehicle
+	testObj := Vehicle[Bike]{
+		Year:  2022,
+		Make:  ToPointer("Porsche"),
+		Model: ToPointer("Taycan turbo GT"),
+		AdditionalProperties: map[string]Bike{
+			"bike": Bike{
+				Id:   2013,
+				Roof: ToPointer("Chopper"),
+				Type: ToPointer("Yamaha V Max"),
+			},
+		},
+	}
+	// Serializing testObj to JSON
+	if serializedObject, err := json.Marshal(testObj); err != nil {
+		t.Error(err)
+	} else {
+		fmt.Printf("serializedObject: %v\n", string(serializedObject))
+	}
+
+	// JSON string to be deserialized
+	jsonString := `{"bike":{"id":2013,"roof":"Chopper","type":"Yamaha V Max"},"make":"Porsche","model":"Taycan turbo GT","year":2022}`
+
+	var deserializedObject Vehicle[Bike]
+	// Deserializing JSON string to struct
+	if err := json.Unmarshal([]byte(jsonString), &deserializedObject); err != nil {
+		t.Error(err)
+	}
+
+	// Verifying if the deserialized object matches the original
+	if !reflect.DeepEqual(testObj, deserializedObject) {
+		t.Error("Test_Float64_Vehicle struct failed.")
+	}
+}
+
+func Test_AnyOfNumberVehicleVehicle(t *testing.T) {
+	// Creating an instance of Vehicle
+	testObj := Vehicle[AnyOfNumberVehicle]{
+		Year:  2022,
+		Make:  ToPointer("Porsche"),
+		Model: ToPointer("Taycan turbo GT"),
+		AdditionalProperties: map[string]AnyOfNumberVehicle{
+			"top_speed": AnyOfNumberBooleanContainer.FromNumber(290),
+			"fav_bike": AnyOfNumberBooleanContainer.FromVehicle(Vehicle[bool]{
+				Year:  2013,
+				Make:  ToPointer("Yamaha"),
+				Model: ToPointer("Chopper V Max"),
+				AdditionalProperties: map[string]bool{
+					"is_chopper": true,
+				},
+			}),
+		},
+	}
+	// Serializing testObj to JSON
+	serializedObject, err := json.Marshal(testObj)
+	if err != nil {
+		t.Error(err)
+	} else {
+		fmt.Printf("serializedObject: %v\n", string(serializedObject))
+	}
+
+	// JSON string to be deserialized
+	jsonString := `{"make":"Porsche", "model":"Taycan turbo GT", "year":2022, "top_speed":290, "fav_bike":{"is_chopper":true,"make":"Yamaha","model":"Chopper V Max","year":2013, "addProp1":"invalid"}, "addProp2":"invalid2"}`
+
+	var deserializedObject Vehicle[AnyOfNumberVehicle]
+	// Deserializing JSON string to struct
+	if err := json.Unmarshal([]byte(jsonString), &deserializedObject); err != nil {
+		t.Error(err)
+	}
+
+	var testMap, objMap = make(map[string]any), make(map[string]any)
+	objBytes, _ := json.Marshal(deserializedObject)
+
+	json.Unmarshal(serializedObject, &testMap)
+	json.Unmarshal(objBytes, &objMap)
+
+	// Verifying if the deserialized object matches the original
+	if !reflect.DeepEqual(testMap, objMap) {
+		t.Error("Test_Float64_Vehicle struct failed.")
+	}
+}


### PR DESCRIPTION
## What
This PR updates model classes to support strongly typed additional properties instead of the generic `any` type. The changes enforce specific data types for additional properties, allowing user-defined types and aligning the model classes more closely with OpenAPI specifications.

## Why
Previously, additional properties in model classes were defined with `any` type, compromising type safety. This made it difficult to enforce specific data types and led to potential runtime errors and unexpected behavior with user-defined types. With this enhancement, developers can specify types for additional properties, ensuring:
1. Improved type safety and alignment with OpenAPI specs.
2. Greater consistency, which reduces the risk of runtime errors and enhances robustness across various use cases.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Breaking change
No breaking changes were introduced in this PR.

## Testing
Added new unit tests for typed additional Properties.

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
