### PR TITLE
ci/add sonar qube scan

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,0 @@
-exclude_paths:
-  - "**/mock_*.go"
-  - "**/*_test.go"
-  - "assert/*"

--- a/.github/workflows/publishCoverage.yaml
+++ b/.github/workflows/publishCoverage.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: go test ./... -coverprofile=c.out
       - name: SonarQube Scan
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: SonarSource/sonarqube-scan-action@v5.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publishCoverage.yaml
+++ b/.github/workflows/publishCoverage.yaml
@@ -1,6 +1,8 @@
 name: Publish Test Coverage Report
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
     branches: [ main ]
 
@@ -14,10 +16,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.18'
-      - name: Upload coverage report to CodeClimate
-        uses: paambaati/codeclimate-action@v3.2.0
+
+      - name: Run tests and generate coverage report
+        run: go test ./... -coverprofile=c.out
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5.2.0
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageCommand: go test ./... -coverprofile c.out
-          prefix: github.com/apimatic/go-core-runtime
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Getting Started with Go Core Runtime
 [![Go Reference](https://pkg.go.dev/badge/github.com/apimatic/go-core-runtime.svg)](https://pkg.go.dev/github.com/apimatic/go-core-runtime)
 [![GitHub release](https://img.shields.io/github/v/release/apimatic/go-core-runtime)](https://pkg.go.dev/github.com/apimatic/go-core-runtime?tab=versions)
+[![Test Coverage][coverage-badge]][coverage-url]
+[![Maintainability Rating][maintainability-badge]][maintainability-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Licence][license-badge]][license-url]
 [![Tests][test-badge]][test-url]
-[![Test Coverage](https://api.codeclimate.com/v1/badges/2c5a5f8dca8e970ac36e/test_coverage)](https://codeclimate.com/github/apimatic/go-core-runtime/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/2c5a5f8dca8e970ac36e/maintainability)](https://codeclimate.com/github/apimatic/go-core-runtime/maintainability)
+
 
 ## Introduction
 
@@ -111,3 +113,9 @@ For any questions or support, please feel free to contact us at support@apimatic
 [license-url]: LICENSE
 [test-badge]: https://github.com/apimatic/go-core-runtime/actions/workflows/test.yaml/badge.svg
 [test-url]: https://github.com/apimatic/go-core-runtime/actions/workflows/test.yaml
+[coverage-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_go-core-runtime&metric=coverage
+[coverage-url]: https://sonarcloud.io/summary/new_code?id=apimatic_go-core-runtime
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_go-core-runtime&metric=sqale_rating
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_go-core-runtime
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_go-core-runtime&metric=vulnerabilities
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_go-core-runtime

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=apimatic_go-core-runtime
+sonar.projectName=Go Core Runtime
+sonar.organization=apimatic
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=.
+sonar.inclusions=**/*.go
+sonar.exclusions=**/*_test.go
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+
+sonar.go.coverage.reportPaths=c.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.sourceEncoding=UTF-8
 
 sonar.sources=.
 sonar.inclusions=**/*.go
-sonar.exclusions=**/*_test.go
+sonar.exclusions=**/*_test.go,**/mock_*.go,assert/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
This PR migrates the coverage reporting from Code Climate to SonarCloud. It also adds badges from SonarCloud in Readme.